### PR TITLE
feat: HTTP/3 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,11 +49,16 @@ futures-channel = { version = "0.3.14", default-features = false }
 futures-timer = "3"
 futures-util = { version = "0.3.14", default-features = false }
 gloo-net = { version = "0.6.0", default-features = false }
+h3 = "0.0.8"
+h3-quinn = "0.0.10"
 heck = "0.5.0"
+quinn = "0.11"
+rcgen = "0.13"
 http = "1"
 http-body = "1"
 http-body-util = "0.1.0"
 hyper = "1.5"
+quinn-proto = "0.11.0"
 hyper-rustls = { version = "0.27", default-features = false }
 hyper-util = "0.1"
 parking_lot = "0.12"
@@ -65,6 +70,7 @@ rand = "0.9"
 route-recognizer = "0.3.1"
 rustc-hash = "2"
 rustls = { version = "0.23", default-features = false }
+rustls-pemfile = "2.2"
 rustls-pki-types = "1"
 rustls-platform-verifier = "0.5"
 serde = { version = "1", default-features = false, features = ["derive"] }
@@ -84,6 +90,7 @@ wasm-bindgen-futures = "0.4.19"
 
 # Dev dependencies
 anyhow = "1"
+clap = { version = "4.4", features = ["derive"] }
 console-subscriber = "0.4"
 criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
 fast-socks5 = "0.10"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -21,6 +21,8 @@ jsonrpc-pubsub = { version = "18.0.0", optional = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 console-subscriber = { workspace = true }
+hyper = { workspace = true }
+http.workspace = true
 
 [[bench]]
 name = "bench"
@@ -30,3 +32,5 @@ harness = false
 [features]
 # Run benchmarks against servers in https://github.com/paritytech/jsonrpc/
 jsonrpc-crate = ["jsonrpc-ws-server", "jsonrpc-http-server", "jsonrpc-pubsub"]
+# HTTP/3 support for benchmarks
+http3 = ["jsonrpsee/http3"]

--- a/benches/README.md
+++ b/benches/README.md
@@ -35,7 +35,7 @@ HTTP/3 uses the QUIC protocol which runs over UDP. When benchmarking HTTP/3:
 For more reliable HTTP/3 benchmarks, consider using the dedicated script:
 
 ```sh
-./scripts/benchmark_http.sh
+./scripts/bench_http.sh
 ```
 
 ## Run all benchmarks

--- a/benches/README.md
+++ b/benches/README.md
@@ -17,6 +17,27 @@ sudo sysctl -w kern.ipc.maxsockbuf=16777216
 In general, if you run into issues, it may be better to run this on a linux
 box; MacOS seems to hit limits quicker in general.
 
+## HTTP/3 Benchmarking Considerations
+
+HTTP/3 uses the QUIC protocol which runs over UDP. When benchmarking HTTP/3:
+
+1. **UDP Permissions**: Some environments restrict UDP traffic or require special permissions
+2. **Certificate Verification**: HTTP/3 requires TLS, and our benchmarks use self-signed certificates
+3. **Resource Limits**: You may need to increase UDP buffer sizes:
+
+   ```sh
+   sudo sysctl -w net.core.rmem_max=2500000
+   sudo sysctl -w net.core.wmem_max=2500000
+   ```
+
+4. **Firewall Settings**: Ensure UDP traffic is allowed on the benchmark ports
+
+For more reliable HTTP/3 benchmarks, consider using the dedicated script:
+
+```sh
+./scripts/benchmark_http.sh
+```
+
 ## Run all benchmarks
 
 `$ cargo bench`
@@ -24,6 +45,10 @@ box; MacOS seems to hit limits quicker in general.
 It's also possible to run individual benchmarks by:
 
 `$ cargo bench --bench bench jsonrpsee_types_v2_array_ref`
+
+## Run HTTP/3 benchmarks
+
+`$ cargo bench --features http3 -- http3`
 
 ## Run all benchmarks against [jsonrpc crate servers](https://github.com/paritytech/jsonrpc/)
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,10 +4,14 @@ use std::time::Duration;
 use criterion::*;
 use futures_util::future::{FutureExt, join_all};
 use futures_util::stream::FuturesUnordered;
+#[cfg(all(not(feature = "jsonrpc-crate"), feature = "http3"))]
+use helpers::fixed_client::http3_client;
 use helpers::fixed_client::{
 	ArrayParams, BatchRequestBuilder, ClientT, HeaderMap, SubscriptionClientT, http_client, rpc_params, ws_client,
 	ws_handshake,
 };
+#[cfg(all(not(feature = "jsonrpc-crate"), feature = "http3"))]
+use helpers::http3_server;
 use helpers::{KIB, SUB_METHOD_NAME, UNSUB_METHOD_NAME};
 use jsonrpsee::types::{Id, Request};
 use pprof::criterion::{Output, PProfProfiler};
@@ -32,41 +36,123 @@ criterion_group!(
 	config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
 	targets = jsonrpsee_types_v2
 );
+#[cfg(not(feature = "http3"))]
 criterion_group!(
 	name = sync_benches;
 	config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
 	targets = SyncBencher::http_benches, SyncBencher::websocket_benches
 );
+
+#[cfg(all(not(feature = "jsonrpc-crate"), feature = "http3"))]
+criterion_group!(
+	name = sync_benches;
+	config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+	targets = SyncBencher::http_benches, SyncBencher::websocket_benches, SyncBencher::http3_benches
+);
+
+#[cfg(not(feature = "http3"))]
 criterion_group!(
 	name = sync_benches_mid;
 	config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None))).measurement_time(measurement_mid());
 	targets = SyncBencher::http_benches_mid, SyncBencher::websocket_benches_mid
 );
+
+#[cfg(all(not(feature = "jsonrpc-crate"), feature = "http3"))]
+criterion_group!(
+	name = sync_benches_mid;
+	config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None))).measurement_time(measurement_mid());
+	targets = SyncBencher::http_benches_mid, SyncBencher::websocket_benches_mid, SyncBencher::http3_benches_mid
+);
+
+#[cfg(not(feature = "http3"))]
 criterion_group!(
 	name = sync_benches_slow;
 	config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None))).measurement_time(measurement_time_slow());
 	targets = SyncBencher::http_benches_slow, SyncBencher::websocket_benches_slow
 );
+
+#[cfg(all(not(feature = "jsonrpc-crate"), feature = "http3"))]
+criterion_group!(
+	name = sync_benches_slow;
+	config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None))).measurement_time(measurement_time_slow());
+	targets = SyncBencher::http_benches_slow, SyncBencher::websocket_benches_slow, SyncBencher::http3_benches_slow
+);
+
+#[cfg(not(feature = "http3"))]
 criterion_group!(
 	name = async_benches;
 	config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
 	targets = AsyncBencher::http_benches, AsyncBencher::websocket_benches
 );
+
+#[cfg(all(not(feature = "jsonrpc-crate"), feature = "http3"))]
+criterion_group!(
+	name = async_benches;
+	config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+	targets = AsyncBencher::http_benches, AsyncBencher::websocket_benches, AsyncBencher::http3_benches
+);
+
+#[cfg(not(feature = "http3"))]
 criterion_group!(
 	name = async_benches_mid;
 	config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None))).measurement_time(measurement_mid());
 	targets = AsyncBencher::http_benches_mid, AsyncBencher::websocket_benches_mid
 );
+
+#[cfg(all(not(feature = "jsonrpc-crate"), feature = "http3"))]
+criterion_group!(
+	name = async_benches_mid;
+	config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None))).measurement_time(measurement_mid());
+	targets = AsyncBencher::http_benches_mid, AsyncBencher::websocket_benches_mid, AsyncBencher::http3_benches_mid
+);
+
+#[cfg(not(feature = "http3"))]
 criterion_group!(
 	name = async_slow_benches;
 	config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None))).measurement_time(measurement_time_slow());
 	targets = AsyncBencher::http_benches_slow, AsyncBencher::websocket_benches_slow
+);
+
+#[cfg(all(not(feature = "jsonrpc-crate"), feature = "http3"))]
+criterion_group!(
+	name = async_slow_benches;
+	config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None))).measurement_time(measurement_time_slow());
+	targets = AsyncBencher::http_benches_slow, AsyncBencher::websocket_benches_slow, AsyncBencher::http3_benches_slow
 );
 criterion_group!(
 	name = subscriptions;
 	config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
 	targets = AsyncBencher::subscriptions
 );
+
+#[cfg(not(feature = "http3"))]
+criterion_main!(
+	types_benches,
+	sync_benches,
+	sync_benches_mid,
+	sync_benches_slow,
+	async_benches,
+	async_benches_mid,
+	async_slow_benches,
+	subscriptions
+);
+
+#[cfg(all(not(feature = "jsonrpc-crate"), feature = "http3"))]
+criterion_main!(
+	types_benches,
+	sync_benches,
+	sync_benches_mid,
+	sync_benches_slow,
+	async_benches,
+	async_benches_mid,
+	async_slow_benches,
+	subscriptions
+);
+
+#[cfg(all(feature = "jsonrpc-crate", feature = "http3"))]
+criterion_main!(types_benches, subscriptions);
+
+#[cfg(all(not(feature = "http3"), not(feature = "jsonrpc-crate")))]
 criterion_main!(
 	types_benches,
 	sync_benches,
@@ -182,6 +268,38 @@ trait RequestBencher {
 			crit,
 			&url,
 			"http_concurrent_conn_calls",
+			Self::REQUEST_TYPE,
+			&[128, 256, 512, 1024],
+		);
+	}
+
+	#[cfg(all(not(feature = "jsonrpc-crate"), feature = "http3"))]
+	fn http3_benches(crit: &mut Criterion) {
+		let rt = TokioRuntime::new().unwrap();
+		let (url, _server) = rt.block_on(http3_server(rt.handle().clone()));
+		let client = Arc::new(rt.block_on(http3_client(&url, HeaderMap::new())));
+		http3_custom_headers_round_trip(&rt, crit, &url, "http3_custom_headers_round_trip", Self::REQUEST_TYPE);
+		http3_concurrent_conn_calls(&rt, crit, &url, "http3_concurrent_conn_calls", Self::REQUEST_TYPE, &[2, 4, 8]);
+		round_trip(&rt, crit, client.clone(), "http3_round_trip", Self::REQUEST_TYPE);
+		batch_round_trip(&rt, crit, client, "http3_batch_requests", Self::REQUEST_TYPE);
+	}
+
+	#[cfg(all(not(feature = "jsonrpc-crate"), feature = "http3"))]
+	fn http3_benches_mid(crit: &mut Criterion) {
+		let rt = TokioRuntime::new().unwrap();
+		let (url, _server) = rt.block_on(http3_server(rt.handle().clone()));
+		http3_concurrent_conn_calls(&rt, crit, &url, "http3_concurrent_conn_calls", Self::REQUEST_TYPE, &[16, 32, 64]);
+	}
+
+	#[cfg(all(not(feature = "jsonrpc-crate"), feature = "http3"))]
+	fn http3_benches_slow(crit: &mut Criterion) {
+		let rt = TokioRuntime::new().unwrap();
+		let (url, _server) = rt.block_on(http3_server(rt.handle().clone()));
+		http3_concurrent_conn_calls(
+			&rt,
+			crit,
+			&url,
+			"http3_concurrent_conn_calls",
 			Self::REQUEST_TYPE,
 			&[128, 256, 512, 1024],
 		);
@@ -522,4 +640,77 @@ fn ws_custom_headers_handshake(rt: &TokioRuntime, crit: &mut Criterion, url: &st
 		});
 	}
 	group.finish();
+}
+
+#[cfg(all(not(feature = "jsonrpc-crate"), feature = "http3"))]
+fn http3_concurrent_conn_calls(
+	rt: &TokioRuntime,
+	crit: &mut Criterion,
+	url: &str,
+	name: &str,
+	request: RequestType,
+	concurrent_conns: &[usize],
+) {
+	let fast_call = request.methods()[0];
+	assert!(fast_call.starts_with("fast_call"));
+
+	let bench_name = format!("{}/{}", name, fast_call);
+	let mut group = crit.benchmark_group(request.group_name(&bench_name));
+	for conns in concurrent_conns.iter() {
+		group.bench_function(format!("{}", conns), |b| {
+			b.to_async(rt).iter_with_setup(
+				|| {
+					let mut clients = Vec::new();
+					// We have to use `block_in_place` here since `b.to_async(rt)` automatically enters the
+					// runtime context and simply calling `block_on` here will cause the code to panic.
+					tokio::task::block_in_place(|| {
+						tokio::runtime::Handle::current().block_on(async {
+							for _ in 0..*conns {
+								clients.push(http3_client(url, HeaderMap::new()).await);
+							}
+						})
+					});
+
+					clients
+				},
+				|clients| async {
+					let tasks = clients.into_iter().map(|client| {
+						rt.spawn(async move {
+							client.request::<String, ArrayParams>(fast_call, rpc_params![]).await.unwrap();
+						})
+					});
+					join_all(tasks).await;
+				},
+			)
+		});
+	}
+	group.finish();
+}
+
+#[cfg(all(not(feature = "jsonrpc-crate"), feature = "http3"))]
+fn http3_custom_headers_round_trip(
+	rt: &TokioRuntime,
+	crit: &mut Criterion,
+	url: &str,
+	name: &str,
+	request: RequestType,
+) {
+	let fast_call = request.methods()[0];
+	assert!(fast_call.starts_with("fast_call"));
+
+	for header_size in [0, KIB, 5 * KIB, 25 * KIB, 100 * KIB] {
+		let mut headers = HeaderMap::new();
+		if header_size != 0 {
+			headers.insert("key", "A".repeat(header_size).parse().unwrap());
+		}
+
+		let client = Arc::new(rt.block_on(http3_client(url, headers)));
+		let bench_name = format!("{}/{}kb", name, header_size / KIB);
+
+		crit.bench_function(&request.group_name(&bench_name), |b| {
+			b.to_async(rt).iter(|| async {
+				black_box(client.request::<String, ArrayParams>(fast_call, rpc_params![]).await.unwrap());
+			})
+		});
+	}
 }

--- a/client/http-client/Cargo.toml
+++ b/client/http-client/Cargo.toml
@@ -18,12 +18,22 @@ workspace = true
 
 [dependencies]
 base64 = { workspace = true }
+bytes = { workspace = true }
 hyper = { workspace = true, features = ["client", "http1", "http2"] }
 hyper-rustls = { workspace = true, features = ["http1", "http2", "tls12", "logging", "ring"], optional = true }
 hyper-util = { workspace = true, features = ["client", "client-legacy", "tokio", "http1", "http2"] }
+futures = { workspace = true }
+h3 = { workspace = true, optional = true }
+h3-quinn = { workspace = true, optional = true }
+http = { workspace = true }
 http-body = { workspace = true }
+http-body-util = { workspace = true }
 jsonrpsee-types = { workspace = true }
 jsonrpsee-core = { workspace = true, features = ["client", "http-helpers"] }
+quinn = { workspace = true, optional = true }
+quinn-proto = { workspace = true, optional = true }
+rustls-native-certs = { version = "0.8", optional = true }
+tracing = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true, features = ["logging", "std", "tls12", "ring"] }
 rustls-platform-verifier = { workspace = true, optional = true }
 serde = { workspace = true }
@@ -41,6 +51,7 @@ tokio = { workspace = true, features = ["net", "rt-multi-thread", "macros"] }
 [features]
 default = ["tls"]
 tls = ["hyper-rustls", "rustls", "rustls-platform-verifier"]
+http3 = ["h3", "h3-quinn", "quinn", "quinn-proto", "tracing", "rustls-native-certs"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/client/http-client/src/http3.rs
+++ b/client/http-client/src/http3.rs
@@ -1,0 +1,926 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use bytes::{Buf, Bytes};
+use h3::client::{self};
+use h3_quinn::Connection as H3QuinnConnection;
+use http::Request;
+use http_body::Body as HttpBody;
+use jsonrpsee_core::http_helpers::{Body, HttpError};
+use quinn::{ClientConfig, Connection, Endpoint, TransportConfig, VarInt};
+use rustls::RootCertStore;
+use tokio::sync::Mutex;
+use tower::Service;
+use tracing::{debug, info, trace, warn};
+use url::Url;
+
+use crate::transport::Error;
+use crate::{HttpRequest, HttpResponse};
+
+/// HTTP/3 client implementation with connection pooling and advanced configuration options
+#[derive(Clone, Debug)]
+pub struct Http3Client {
+	/// QUIC endpoint for establishing connections
+	endpoint: Arc<Endpoint>,
+	/// Configuration for the HTTP/3 client
+	config: Http3Config,
+	/// TLS client configuration
+	client_config: Arc<ClientConfig>,
+	/// Connection pool for reusing connections
+	connections: Arc<Mutex<HashMap<String, ConnectionEntry>>>,
+}
+
+/// Predefined workload profiles for HTTP/3 configuration
+///
+/// These profiles provide optimized settings for different types of workloads.
+#[derive(Clone, Debug, Copy)]
+pub enum WorkloadProfile {
+	/// Optimized for low latency mode
+	///
+	/// This profile prioritizes response time over throughput with smaller
+	/// buffer sizes and more aggressive timeouts.
+	LowLatency,
+
+	/// Optimized for high throughput mode
+	///
+	/// This profile prioritizes data transfer rates over latency with larger
+	/// buffer sizes and more relaxed timeouts.
+	HighThroughput,
+
+	/// Balanced profile with moderate settings
+	///
+	/// This profile provides a good balance between latency and throughput.
+	Balanced,
+
+	/// Custom profile with user-defined settings
+	///
+	/// Use this when we want to manually configure all HTTP/3 settings.
+	Custom,
+}
+
+/// Configuration options for HTTP/3 client
+#[derive(Clone, Debug, Copy)]
+pub struct Http3Config {
+	/// Maximum number of concurrent requests allowed
+	pub max_concurrent_requests: usize,
+	/// Request timeout duration
+	pub request_timeout: Option<Duration>,
+	/// Maximum size of request body in bytes
+	pub max_request_body_size: usize,
+	/// Maximum size of response body in bytes
+	pub max_response_body_size: usize,
+	/// Enable 0-RTT for faster connection establishment
+	pub enable_0rtt: bool,
+	/// Maximum idle timeout for QUIC connections
+	pub max_idle_timeout: Duration,
+	/// Interval for sending keep-alive probes
+	pub keep_alive_interval: Option<Duration>,
+	/// Maximum number of connections to maintain per host
+	pub max_connections_per_host: usize,
+	/// Timeout duration for idle connections
+	pub connection_idle_timeout: Duration,
+	/// Enable adaptive flow control for better performance
+	pub enable_adaptive_flow_control: bool,
+	/// Enable various performance optimizations
+	pub enable_performance_optimizations: bool,
+	/// Multiplier for maximum concurrent streams
+	pub max_concurrent_streams_multiplier: u32,
+	/// Size of the receive window in bytes
+	pub receive_window_size: u32,
+	/// Size of the send buffer in bytes
+	pub send_buffer_size: u32,
+	/// Enable BBR congestion control algorithm
+	pub enable_bbr_congestion_control: bool,
+	/// Initial round-trip time estimate in milliseconds
+	pub initial_rtt_ms: u32,
+	/// Factor by which buffers can grow
+	pub buffer_growth_factor: u32,
+	/// Certificate verification mode
+	pub certificate_verification_mode: CertificateVerificationMode,
+}
+
+/// Certificate verification modes for HTTP/3 client
+#[derive(Clone, Debug, Copy)]
+pub enum CertificateVerificationMode {
+	/// Standard verification using system trust store (default, recommended for production)
+	Standard,
+
+	/// Accept self-signed certificates (for testing only)
+	AcceptSelfSigned,
+
+	/// Skip certificate verification entirely (dangerous, for testing only)
+	NoVerification,
+}
+
+impl Default for CertificateVerificationMode {
+	fn default() -> Self {
+		Self::Standard
+	}
+}
+
+impl Http3Config {
+	/// Create a configuration optimized for a specific workload profile
+	pub fn for_workload(profile: WorkloadProfile) -> Self {
+		match profile {
+			WorkloadProfile::LowLatency => Self {
+				max_concurrent_requests: 50,
+				request_timeout: Some(Duration::from_secs(30)),
+				max_request_body_size: 10 * 1024 * 1024,  // 10 MiB
+				max_response_body_size: 10 * 1024 * 1024, // 10 MiB
+				enable_0rtt: true,
+				max_idle_timeout: Duration::from_secs(15),
+				keep_alive_interval: Some(Duration::from_secs(2)),
+				max_connections_per_host: 4,
+				connection_idle_timeout: Duration::from_secs(30),
+				enable_adaptive_flow_control: true,
+				enable_performance_optimizations: true,
+				max_concurrent_streams_multiplier: 1,
+				receive_window_size: 8 * 1024 * 1024,
+				send_buffer_size: 4 * 1024 * 1024,
+				enable_bbr_congestion_control: true,
+				initial_rtt_ms: 20,
+				buffer_growth_factor: 1,
+				certificate_verification_mode: CertificateVerificationMode::Standard,
+			},
+			WorkloadProfile::HighThroughput => Self {
+				max_concurrent_requests: 200,
+				request_timeout: Some(Duration::from_secs(120)),
+				max_request_body_size: 20 * 1024 * 1024,  // 20 MiB
+				max_response_body_size: 20 * 1024 * 1024, // 20 MiB
+				enable_0rtt: true,
+				max_idle_timeout: Duration::from_secs(60),
+				keep_alive_interval: Some(Duration::from_secs(10)),
+				max_connections_per_host: 16,
+				connection_idle_timeout: Duration::from_secs(120),
+				enable_adaptive_flow_control: true,
+				enable_performance_optimizations: true,
+				max_concurrent_streams_multiplier: 4,
+				receive_window_size: 32 * 1024 * 1024,
+				send_buffer_size: 16 * 1024 * 1024,
+				enable_bbr_congestion_control: true,
+				initial_rtt_ms: 100,
+				buffer_growth_factor: 3,
+				certificate_verification_mode: CertificateVerificationMode::Standard,
+			},
+			WorkloadProfile::Balanced => Self::default(),
+			WorkloadProfile::Custom => Self::default(),
+		}
+	}
+}
+
+impl Default for Http3Config {
+	fn default() -> Self {
+		Self {
+			max_concurrent_requests: 100,
+			request_timeout: Some(Duration::from_secs(60)),
+			max_request_body_size: 15 * 1024 * 1024,  // 15 MiB
+			max_response_body_size: 15 * 1024 * 1024, // 15 MiB
+			enable_0rtt: true,
+			max_idle_timeout: Duration::from_secs(30),
+			keep_alive_interval: Some(Duration::from_secs(5)),
+			max_connections_per_host: 8,
+			connection_idle_timeout: Duration::from_secs(60),
+			enable_adaptive_flow_control: true,
+			enable_performance_optimizations: true,
+			max_concurrent_streams_multiplier: 2,
+			receive_window_size: 16 * 1024 * 1024,
+			send_buffer_size: 8 * 1024 * 1024,
+			enable_bbr_congestion_control: true,
+			initial_rtt_ms: 50,
+			buffer_growth_factor: 2,
+			certificate_verification_mode: CertificateVerificationMode::Standard,
+		}
+	}
+}
+
+/// Connection health metrics for HTTP/3 connections
+#[derive(Debug, Clone, Copy)]
+pub struct ConnectionHealthMetrics {
+	/// Average round-trip time for the connection
+	pub avg_rtt: Option<Duration>,
+	/// Packet loss rate (0.0-1.0)
+	pub packet_loss_rate: f32,
+	/// Throughput in bits per second
+	pub throughput_bps: u64,
+	/// Connection stability score (0.0-1.0)
+	pub connection_stability_score: f32,
+	/// Last time the metrics were updated
+	pub last_updated: std::time::Instant,
+	/// Total bytes sent over this connection
+	pub bytes_sent: u64,
+	/// Total bytes received over this connection
+	pub bytes_received: u64,
+	/// Number of connection errors encountered
+	pub connection_errors: u32,
+}
+
+impl Default for ConnectionHealthMetrics {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+impl ConnectionHealthMetrics {
+	/// Create new connection health metrics with default values
+	pub fn new() -> Self {
+		Self {
+			avg_rtt: None,
+			packet_loss_rate: 0.0,
+			throughput_bps: 0,
+			connection_stability_score: 1.0,
+			last_updated: std::time::Instant::now(),
+			bytes_sent: 0,
+			bytes_received: 0,
+			connection_errors: 0,
+		}
+	}
+
+	/// Updates the throughput metric based on bytes transferred and elapsed time
+	///
+	/// Calculates bits per second based on the provided byte count and duration.
+	pub fn update_throughput(&mut self, bytes: u64, elapsed: Duration) {
+		if elapsed.as_secs_f64() > 0.0 {
+			self.throughput_bps = (bytes as f64 / elapsed.as_secs_f64()) as u64;
+		}
+	}
+
+	/// Updates the packet loss rate based on lost and total packets
+	///
+	/// Calculates the ratio of lost packets to total packets.
+	pub fn update_packet_loss(&mut self, lost: u32, total: u32) {
+		if total > 0 {
+			self.packet_loss_rate = lost as f32 / total as f32;
+		}
+	}
+
+	/// Updates the average round-trip time with a new measurement
+	///
+	/// Uses an exponential moving average to smooth RTT values.
+	pub fn update_rtt(&mut self, new_rtt: Duration) {
+		self.avg_rtt = if let Some(avg) = self.avg_rtt {
+			Some(Duration::from_micros((avg.as_micros() as u64 * 3 + new_rtt.as_micros() as u64) / 4))
+		} else {
+			Some(new_rtt)
+		};
+	}
+
+	/// Calculates a stability score based on various metrics
+	///
+	/// Returns a value between 0.0 and 1.0 where higher values indicate better stability.
+	pub fn calculate_stability_score(&mut self) -> f32 {
+		let rtt_factor = if let Some(rtt) = self.avg_rtt {
+			1.0 - (rtt.as_millis() as f32 / 500.0).min(1.0)
+		} else {
+			0.5 // Neutral if we don't have RTT data
+		};
+
+		let loss_factor = 1.0 - self.packet_loss_rate;
+
+		let error_factor = 1.0 - (self.connection_errors as f32 / 100.0).min(1.0);
+
+		let throughput_factor = (self.throughput_bps as f32 / 1_000_000.0).min(1.0);
+
+		self.connection_stability_score =
+			(rtt_factor * 0.3 + loss_factor * 0.3 + error_factor * 0.2 + throughput_factor * 0.2).clamp(0.0, 1.0);
+
+		self.connection_stability_score
+	}
+
+	/// Updates metrics from QUIC connection statistics
+	///
+	/// Extracts and processes relevant metrics from the quinn connection stats.
+	pub fn update_from_stats(&mut self, stats: &quinn::ConnectionStats) {
+		self.update_rtt(stats.path.rtt);
+
+		let lost_packets = stats.path.lost_packets as u32;
+		let total_packets = stats.path.sent_packets as u32;
+		self.update_packet_loss(lost_packets, total_packets);
+
+		self.calculate_stability_score();
+
+		self.last_updated = std::time::Instant::now();
+	}
+}
+
+/// Connection entry with health metrics for HTTP/3 connections
+struct ConnectionEntry {
+	/// The QUIC connection
+	connection: Connection,
+	/// When the connection was last used
+	last_used: std::time::Instant,
+	/// Number of requests made on this connection
+	request_count: usize,
+	/// Total bytes sent over this connection
+	bytes_sent: usize,
+	/// Total bytes received over this connection
+	bytes_received: usize,
+	/// Health score for connection quality (0-10)
+	health_score: f32,
+	/// Detailed health metrics for this connection
+	health_metrics: ConnectionHealthMetrics,
+}
+
+impl std::fmt::Debug for ConnectionEntry {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ConnectionEntry")
+			.field("last_used", &self.last_used)
+			.field("request_count", &self.request_count)
+			.field("bytes_sent", &self.bytes_sent)
+			.field("bytes_received", &self.bytes_received)
+			.field("health_score", &self.health_score)
+			.field("health_metrics", &self.health_metrics)
+			.finish()
+	}
+}
+
+impl Http3Client {
+	/// Creates a new HTTP/3 client with the specified configuration.
+	///
+	/// # Arguments
+	///
+	/// * `_url` - The base URL for the client (currently unused)
+	/// * `config` - Configuration options for the HTTP/3 client
+	///
+	/// # Returns
+	///
+	/// Returns a Result containing the new HTTP/3 client instance or an Error
+	pub async fn new(_url: &Url, config: Http3Config) -> Result<Self, Error> {
+		let mut root_store = RootCertStore::empty();
+
+		// Load native certificates for standard verification
+		if matches!(config.certificate_verification_mode, CertificateVerificationMode::Standard) {
+			for cert in rustls_native_certs::load_native_certs().expect("could not load platform certs") {
+				root_store.add(cert).map_err(|e| {
+					Error::Http(HttpError::Stream(Box::new(std::io::Error::other(format!(
+						"Failed to add certificate to root store: {}",
+						e
+					)))))
+				})?;
+			}
+		}
+
+		// let mut tls_config = rustls::ClientConfig::builder().with_root_certificates(root_store).with_no_client_auth();
+		// tls_config.alpn_protocols = vec![b"h3".to_vec()];
+
+		let tls_config = match config.certificate_verification_mode {
+			CertificateVerificationMode::Standard => {
+				// Standard verification with system trust store
+				let mut config =
+					rustls::ClientConfig::builder().with_root_certificates(root_store).with_no_client_auth();
+
+				config.alpn_protocols = vec![b"h3".to_vec()];
+				config
+			}
+
+			/*CertificateVerificationMode::AcceptSelfSigned => {
+				// Custom verifier that accepts self-signed certificates
+				#[derive(Debug)]
+				struct SelfSignedCertVerifier {
+					root_store: RootCertStore,
+				}
+
+				impl rustls::client::danger::ServerCertVerifier for SelfSignedCertVerifier {
+					fn verify_server_cert(
+						&self,
+						end_entity: &rustls::pki_types::CertificateDer<'_>,
+						intermediates: &[rustls::pki_types::CertificateDer<'_>],
+						server_name: &rustls::pki_types::ServerName<'_>,
+						ocsp_response: &[u8],
+						now: rustls::pki_types::UnixTime,
+					) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+						// First try standard verification
+						let standard_verifier =
+							rustls::client::WebPkiServerVerifier::builder(self.root_store.clone().into())
+								.build()
+								.map_err(|e| rustls::Error::General(e.to_string()))?;
+
+						let standard_result = standard_verifier.verify_server_cert(
+							end_entity,
+							intermediates,
+							server_name,
+							ocsp_response,
+							now,
+						);
+
+						// If standard verification fails, accept it anyway (self-signed)
+						if standard_result.is_err() {
+							debug!(
+								"Standard certificate verification failed, accepting as possible self-signed certificate"
+							);
+							Ok(rustls::client::danger::ServerCertVerified::assertion())
+						} else {
+							standard_result
+						}
+					}
+
+					fn verify_tls12_signature(
+						&self,
+						message: &[u8],
+						cert: &rustls::pki_types::CertificateDer<'_>,
+						dss: &rustls::DigitallySignedStruct,
+					) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+						// Try standard verification first
+						let standard_verifier =
+							rustls::client::WebPkiServerVerifier::builder(self.root_store.clone().into()).build();
+
+						if let Ok(verifier) = standard_verifier {
+							if let Ok(result) = verifier.verify_tls12_signature(message, cert, dss) {
+								return Ok(result);
+							}
+						}
+
+						// Accept signature if verification fails
+						Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+					}
+
+					fn verify_tls13_signature(
+						&self,
+						message: &[u8],
+						cert: &rustls::pki_types::CertificateDer<'_>,
+						dss: &rustls::DigitallySignedStruct,
+					) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+						// Try standard verification first
+						let standard_verifier =
+							rustls::client::WebPkiServerVerifier::builder(self.root_store.clone().into()).build();
+
+						if let Ok(verifier) = standard_verifier {
+							if let Ok(result) = verifier.verify_tls13_signature(message, cert, dss) {
+								return Ok(result);
+							}
+						}
+
+						// Accept signature if verification fails
+						Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+					}
+					fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+						// Return standard supported schemes or fallback to common ones
+						let standard_verifier =
+							rustls::client::WebPkiServerVerifier::builder(self.root_store.clone().into()).build();
+
+						if let Ok(verifier) = standard_verifier {
+							verifier.supported_verify_schemes()
+						} else {
+							vec![
+								rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
+								rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
+								rustls::SignatureScheme::RSA_PSS_SHA256,
+								rustls::SignatureScheme::RSA_PKCS1_SHA256,
+							]
+						}
+					}
+				}
+
+				let mut config = rustls::ClientConfig::builder()
+					.dangerous()
+					.with_custom_certificate_verifier(Arc::new(SelfSignedCertVerifier {
+						root_store: root_store.clone(),
+					}))
+					.with_no_client_auth();
+
+				config.alpn_protocols = vec![b"h3".to_vec()];
+				config
+			}*/
+			CertificateVerificationMode::AcceptSelfSigned | CertificateVerificationMode::NoVerification => {
+				// No verification at all (dangerous, only for testing)
+				#[derive(Debug)]
+				struct NoVerification;
+
+				impl rustls::client::danger::ServerCertVerifier for NoVerification {
+					fn verify_server_cert(
+						&self,
+						_: &rustls::pki_types::CertificateDer<'_>,
+						_: &[rustls::pki_types::CertificateDer<'_>],
+						_: &rustls::pki_types::ServerName<'_>,
+						_: &[u8],
+						_: rustls::pki_types::UnixTime,
+					) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+						Ok(rustls::client::danger::ServerCertVerified::assertion())
+					}
+
+					fn verify_tls12_signature(
+						&self,
+						_: &[u8],
+						_: &rustls::pki_types::CertificateDer<'_>,
+						_: &rustls::DigitallySignedStruct,
+					) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+						Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+					}
+
+					fn verify_tls13_signature(
+						&self,
+						_: &[u8],
+						_: &rustls::pki_types::CertificateDer<'_>,
+						_: &rustls::DigitallySignedStruct,
+					) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+						Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+					}
+
+					fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+						vec![
+							rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
+							rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
+							rustls::SignatureScheme::RSA_PSS_SHA256,
+							rustls::SignatureScheme::RSA_PKCS1_SHA256,
+						]
+					}
+				}
+
+				let mut config = rustls::ClientConfig::builder()
+					.dangerous()
+					.with_custom_certificate_verifier(Arc::new(NoVerification))
+					.with_no_client_auth();
+
+				config.alpn_protocols = vec![b"h3".to_vec()];
+				config
+			}
+		};
+
+		let mut transport_config = TransportConfig::default();
+		transport_config.max_concurrent_bidi_streams(VarInt::from_u32(config.max_concurrent_requests as u32));
+		transport_config.max_concurrent_uni_streams(VarInt::from_u32(config.max_concurrent_requests as u32));
+		transport_config.max_idle_timeout(Some(config.max_idle_timeout.try_into().unwrap()));
+
+		if let Some(interval) = config.keep_alive_interval {
+			transport_config.keep_alive_interval(Some(interval));
+		}
+
+		let crypto = quinn::crypto::rustls::QuicClientConfig::try_from(tls_config).map_err(|_e| {
+			Error::Http(HttpError::Stream(Box::new(std::io::Error::other("Failed to create QUIC client config"))))
+		})?;
+		let mut client_config = ClientConfig::new(Arc::new(crypto));
+		client_config.transport_config(Arc::new(transport_config));
+
+		let mut endpoint = Endpoint::client("0.0.0.0:0".parse().unwrap())
+			.map_err(|e| Error::Http(HttpError::Stream(Box::new(std::io::Error::other(format!("{}", e))))))?;
+		endpoint.set_default_client_config(client_config.clone());
+
+		info!("HTTP/3 client initialized with optimized configuration");
+
+		Ok(Self {
+			endpoint: Arc::new(endpoint),
+			config,
+			client_config: Arc::new(client_config),
+			connections: Arc::new(Mutex::new(HashMap::new())),
+		})
+	}
+	/// Gets a connection from the pool or creates a new one
+	///
+	/// This method handles connection pooling, health monitoring, and connection establishment.
+	async fn get_connection(&self, url: &Url) -> Result<Connection, Error> {
+		let host = url.host_str().ok_or_else(|| Error::Url("Missing host in URL".into()))?;
+		let port = url.port().unwrap_or(443);
+		let key = format!("{}:{}", host, port);
+
+		{
+			let mut connections = self.connections.lock().await;
+
+			connections.retain(|_, entry| {
+				let is_valid = entry.connection.close_reason().is_none()
+					&& entry.last_used.elapsed() < self.config.connection_idle_timeout;
+
+				if is_valid {
+					let stats = entry.connection.stats();
+					entry.health_metrics.update_from_stats(&stats);
+
+					if let Some(rtt) = entry.health_metrics.avg_rtt {
+						if rtt > Duration::from_millis(200) {
+							entry.health_score *= 0.9;
+						}
+					}
+
+					if entry.health_metrics.packet_loss_rate > 0.05 {
+						entry.health_score *= 1.0 - entry.health_metrics.packet_loss_rate;
+					}
+
+					if entry.health_metrics.throughput_bps > 1_000_000 && entry.health_score < 10.0 {
+						entry.health_score += 0.2;
+					}
+
+					// Gradually improve score for stable connections
+					if entry.request_count > 0 && entry.health_score < 10.0 {
+						entry.health_score += 0.1;
+					}
+
+					entry.health_score =
+						entry.health_score * 0.8 + entry.health_metrics.connection_stability_score * 2.0 * 0.2;
+				} else {
+					debug!("Removing stale connection from pool");
+				}
+
+				is_valid
+			});
+
+			if let Some(entry) = connections.get_mut(&key) {
+				if entry.health_score >= 5.0 {
+					trace!("Reusing existing connection with health score {}", entry.health_score);
+					entry.last_used = std::time::Instant::now();
+					entry.request_count += 1;
+					return Ok(entry.connection.clone());
+				} else {
+					debug!(
+						"Existing connection has poor health score ({}), creating new connection",
+						entry.health_score
+					);
+				}
+			}
+
+			let host_connections = connections.iter().filter(|(k, _)| k.starts_with(&format!("{}:", host))).count();
+
+			if host_connections >= self.config.max_connections_per_host {
+				let worst_key = connections
+					.iter()
+					.filter(|(k, _)| k.starts_with(&format!("{}:", host)))
+					.min_by(|(_, a), (_, b)| {
+						a.health_score.partial_cmp(&b.health_score).unwrap_or(std::cmp::Ordering::Equal)
+					})
+					.map(|(k, _)| k.clone());
+
+				if let Some(key) = worst_key {
+					connections.remove(&key);
+					debug!("Removed least healthy connection to maintain max connections per host limit");
+				}
+			}
+		}
+
+		let server_name = host.to_string();
+		let addr = format!("{}:{}", host, port).parse().map_err(|e| Error::Url(format!("Invalid address: {}", e)))?;
+
+		debug!("Creating new HTTP/3 connection to {}", addr);
+
+		let mut transport_config = TransportConfig::default();
+
+		transport_config.max_concurrent_bidi_streams(VarInt::from_u32(
+			self.config.max_concurrent_requests as u32 * self.config.max_concurrent_streams_multiplier,
+		));
+		transport_config.max_concurrent_uni_streams(VarInt::from_u32(
+			self.config.max_concurrent_requests as u32 * self.config.max_concurrent_streams_multiplier,
+		));
+
+		transport_config.receive_window(VarInt::from_u32(self.config.receive_window_size));
+		transport_config.send_window(VarInt::from_u32(self.config.send_buffer_size).into());
+
+		transport_config.initial_rtt(Duration::from_millis(self.config.initial_rtt_ms as u64));
+
+		if self.config.enable_bbr_congestion_control {
+			transport_config
+				.congestion_controller_factory(std::sync::Arc::new(quinn::congestion::BbrConfig::default()));
+		}
+
+		let mut client_config = self.client_config.as_ref().clone();
+		client_config.transport_config(Arc::new(transport_config));
+
+		let mut endpoint = self.endpoint.as_ref().clone();
+		endpoint.set_default_client_config(client_config);
+
+		let connecting = self
+			.endpoint
+			.connect(addr, &server_name)
+			.map_err(|e| Error::Http(HttpError::Stream(Box::new(std::io::Error::other(format!("{}", e))))))?;
+
+		let connection = connecting
+			.await
+			.map_err(|e| Error::Http(HttpError::Stream(Box::new(std::io::Error::other(format!("{}", e))))))?;
+
+		let stats = connection.stats();
+		let initial_rtt = stats.path.rtt;
+
+		{
+			let mut connections = self.connections.lock().await;
+			let mut health_metrics = ConnectionHealthMetrics::new();
+			health_metrics.update_rtt(initial_rtt);
+
+			connections.insert(
+				key,
+				ConnectionEntry {
+					connection: connection.clone(),
+					last_used: std::time::Instant::now(),
+					request_count: 0,
+					bytes_sent: 0,
+					bytes_received: 0,
+					health_score: 8.0, // Start with good health score for new connections
+					health_metrics,
+				},
+			);
+
+			info!("Added new HTTP/3 connection to pool with initial RTT: {:?}", initial_rtt);
+		}
+
+		Ok(connection)
+	}
+}
+
+/// Future type for HTTP/3 responses
+type Http3ResponseType = Result<HttpResponse<http_body_util::Full<Bytes>>, Error>;
+/// Boxed future for HTTP/3 responses
+type Http3ResponseFutureInner = Pin<Box<dyn Future<Output = Http3ResponseType> + Send>>;
+
+/// Future returned by HTTP/3 client for response handling
+pub struct Http3ResponseFuture {
+	/// The inner future that will resolve to the HTTP/3 response
+	inner: Http3ResponseFutureInner,
+}
+
+impl std::fmt::Debug for Http3ResponseFuture {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("Http3ResponseFuture").field("inner", &"<future>").finish()
+	}
+}
+
+impl Future for Http3ResponseFuture {
+	type Output = Result<HttpResponse<http_body_util::Full<Bytes>>, Error>;
+
+	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+		Pin::new(&mut self.inner).poll(cx)
+	}
+}
+
+impl Service<HttpRequest<Body>> for Http3Client {
+	type Response = HttpResponse<http_body_util::Full<Bytes>>;
+	type Error = Error;
+	type Future = Http3ResponseFuture;
+
+	fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		Poll::Ready(Ok(()))
+	}
+
+	fn call(&mut self, req: HttpRequest<Body>) -> Self::Future {
+		let client = self.clone();
+		let url = req.uri().to_string().parse::<Url>().unwrap_or_else(|_| {
+			warn!("Failed to parse URI as URL: {}", req.uri());
+			"https://localhost".parse().unwrap()
+		});
+
+		let timeout = self.config.request_timeout;
+		let enable_optimizations = self.config.enable_performance_optimizations;
+
+		let fut = Box::pin(async move {
+			let start_time = std::time::Instant::now();
+
+			let connection = client.get_connection(&url).await?;
+
+			let connection_time = start_time.elapsed();
+			trace!("HTTP/3 connection acquisition took {:?}", connection_time);
+
+			let h3_conn = H3QuinnConnection::new(connection.clone());
+
+			let (parts, body) = req.into_parts();
+
+			let mut request = Request::builder().uri(parts.uri).method(parts.method);
+
+			if enable_optimizations {
+				request = request.header("x-http3-optimized", "true");
+			}
+
+			for (name, value) in parts.headers.iter() {
+				request = request.header(name, value);
+			}
+
+			let h3_request = request
+				.body(())
+				.map_err(|e| Error::Http(HttpError::Stream(Box::new(std::io::Error::other(format!("{}", e))))))?;
+
+			let (mut h3_client, mut send_request) = if enable_optimizations {
+				client::builder()
+					.max_field_section_size(16 * 1024) // Larger header size
+					.build(h3_conn)
+					.await
+			} else {
+				client::builder().build(h3_conn).await
+			}
+			.map_err(|e| Error::Http(HttpError::Stream(Box::new(std::io::Error::other(format!("{}", e))))))?;
+
+			tokio::spawn(async move {
+				let err = h3_client.wait_idle().await;
+				warn!("HTTP/3 connection closed: {}", err);
+			});
+
+			let request_start = std::time::Instant::now();
+			let mut req_stream = if let Some(duration) = timeout {
+				tokio::time::timeout(duration, send_request.send_request(h3_request))
+					.await
+					.map_err(|_| Error::RequestTimeout)?
+					.map_err(|e| Error::Http(HttpError::Stream(Box::new(std::io::Error::other(format!("{}", e))))))?
+			} else {
+				send_request
+					.send_request(h3_request)
+					.await
+					.map_err(|e| Error::Http(HttpError::Stream(Box::new(std::io::Error::other(format!("{}", e))))))?
+			};
+
+			let request_time = request_start.elapsed();
+			trace!("HTTP/3 request initiation took {:?}", request_time);
+
+			if HttpBody::size_hint(&body).exact() != Some(0) {
+				let body_start = std::time::Instant::now();
+				let collected = http_body_util::BodyExt::collect(body)
+					.await
+					.map_err(|e| Error::Http(HttpError::Stream(Box::new(std::io::Error::other(format!("{}", e))))))?;
+
+				let bytes = collected.to_bytes();
+				let body_size = bytes.len();
+
+				if !bytes.is_empty() {
+					let _chunk_size = if body_size > 1024 * 1024 {
+						body_size.min(512 * 1024) // Max 512KB chunks
+					} else if body_size > 64 * 1024 {
+						body_size.min(64 * 1024) // Max 64KB chunks
+					} else {
+						body_size
+					};
+
+					if let Ok(mut connections) = client.connections.try_lock() {
+						if let Some(entry) = connections.get_mut(&format!(
+							"{}:{}",
+							url.host_str().unwrap_or("localhost"),
+							url.port().unwrap_or(443)
+						)) {
+							entry.bytes_sent += body_size;
+						}
+					}
+
+					req_stream.send_data(bytes).await.map_err(|e| {
+						Error::Http(HttpError::Stream(Box::new(std::io::Error::other(format!("{}", e)))))
+					})?;
+
+					trace!("Sent HTTP/3 request body of {} bytes in {:?}", body_size, body_start.elapsed());
+				}
+			}
+
+			req_stream
+				.finish()
+				.await
+				.map_err(|e| Error::Http(HttpError::Stream(Box::new(std::io::Error::other(format!("{}", e))))))?;
+
+			let response_start = std::time::Instant::now();
+			let h3_response = req_stream
+				.recv_response()
+				.await
+				.map_err(|e| Error::Http(HttpError::Stream(Box::new(std::io::Error::other(format!("{}", e))))))?;
+
+			let status = h3_response.status();
+			let version = h3_response.version();
+			let headers = h3_response.headers().clone();
+
+			let initial_capacity = headers
+				.get(http::header::CONTENT_LENGTH)
+				.and_then(|v| v.to_str().ok())
+				.and_then(|s| s.parse::<usize>().ok())
+				.unwrap_or(8 * 1024); // Default 8KB initial capacity
+
+			let mut body_bytes = Vec::with_capacity(initial_capacity);
+			let mut total_bytes = 0;
+
+			loop {
+				match req_stream.recv_data().await {
+					Ok(Some(mut chunk)) => {
+						let chunk_size = chunk.remaining();
+						let bytes = chunk.copy_to_bytes(chunk_size);
+
+						if body_bytes.capacity() < total_bytes + chunk_size {
+							let new_capacity = (total_bytes + chunk_size) * client.config.buffer_growth_factor as usize;
+							body_bytes.reserve(new_capacity - body_bytes.capacity());
+						}
+
+						body_bytes.extend_from_slice(&bytes);
+						total_bytes += chunk_size;
+					}
+					Ok(None) => break,
+					Err(e) => {
+						debug!("Error receiving HTTP/3 data: {:?}", e);
+						break;
+					}
+				}
+			}
+
+			if let Ok(mut connections) = client.connections.try_lock() {
+				if let Some(entry) = connections.get_mut(&format!(
+					"{}:{}",
+					url.host_str().unwrap_or("localhost"),
+					url.port().unwrap_or(443)
+				)) {
+					entry.bytes_received += total_bytes;
+
+					let stats = connection.stats();
+					entry.health_metrics.update_from_stats(&stats);
+				}
+			}
+
+			let response_time = response_start.elapsed();
+			trace!("HTTP/3 response received in {:?} with {} bytes", response_time, total_bytes);
+
+			let response = HttpResponse::builder()
+				.status(status)
+				.version(version)
+				.body(http_body_util::Full::new(Bytes::from(body_bytes)))
+				.map_err(|e| Error::Http(HttpError::Stream(Box::new(std::io::Error::other(format!("{}", e))))))?;
+
+			Ok(response)
+		});
+
+		Http3ResponseFuture { inner: fut }
+	}
+}

--- a/client/http-client/src/lib.rs
+++ b/client/http-client/src/lib.rs
@@ -38,6 +38,18 @@
 mod client;
 mod rpc_service;
 
+#[cfg(feature = "http3")]
+/// HTTP/3 transport.
+pub mod http3;
+#[cfg(feature = "http3")]
+pub use self::http3::{CertificateVerificationMode, Http3Client, Http3Config, WorkloadProfile};
+
+#[cfg(feature = "http3")]
+use {futures as _, h3 as _, h3_quinn as _, http as _, quinn as _, quinn_proto as _};
+
+use futures as _;
+use http as _;
+
 /// HTTP transport.
 pub mod transport;
 

--- a/client/http-client/src/rpc_service.rs
+++ b/client/http-client/src/rpc_service.rs
@@ -15,11 +15,12 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
+/// RPC service that wraps an HTTP transport client and implements the RPC service trait.
 pub struct RpcService<HttpMiddleware> {
 	service: Arc<HttpTransportClient<HttpMiddleware>>,
 }
-
 impl<HttpMiddleware> RpcService<HttpMiddleware> {
+	/// Creates a new RPC service with the given HTTP transport client.
 	pub fn new(service: HttpTransportClient<HttpMiddleware>) -> Self {
 		Self { service: Arc::new(service) }
 	}

--- a/client/http-client/src/tests.rs
+++ b/client/http-client/src/tests.rs
@@ -57,7 +57,7 @@ async fn method_call_with_wrong_id_kind() {
 	let server_addr =
 		http_server_with_hardcoded_response(ok_response(exp.into(), Id::Num(0))).with_default_timeout().await.unwrap();
 	let uri = format!("http://{server_addr}");
-	let client = HttpClientBuilder::default().id_format(IdKind::String).build(&uri).unwrap();
+	let client = HttpClientBuilder::default().id_format(IdKind::String).build(&uri).await.unwrap();
 	let res: Result<String, ClientError> = client.request("o", rpc_params![]).with_default_timeout().await.unwrap();
 	assert!(matches!(res, Err(ClientError::InvalidRequestId(_))));
 }
@@ -70,7 +70,7 @@ async fn method_call_with_id_str() {
 		.await
 		.unwrap();
 	let uri = format!("http://{server_addr}");
-	let client = HttpClientBuilder::default().id_format(IdKind::String).build(&uri).unwrap();
+	let client = HttpClientBuilder::default().id_format(IdKind::String).build(&uri).await.unwrap();
 	let response: String = client.request("o", rpc_params![]).with_default_timeout().await.unwrap().unwrap();
 	assert_eq!(&response, exp);
 }
@@ -79,7 +79,7 @@ async fn method_call_with_id_str() {
 async fn notification_works() {
 	let server_addr = http_server_with_hardcoded_response(String::new()).with_default_timeout().await.unwrap();
 	let uri = format!("http://{server_addr}");
-	let client = HttpClientBuilder::default().build(&uri).unwrap();
+	let client = HttpClientBuilder::default().build(&uri).await.unwrap();
 	client
 		.notification("i_dont_care_about_the_response_because_the_server_should_not_respond", rpc_params![])
 		.with_default_timeout()
@@ -257,14 +257,14 @@ async fn run_batch_request_with_response<T: Send + DeserializeOwned + std::fmt::
 ) -> Result<BatchResponse<T>, ClientError> {
 	let server_addr = http_server_with_hardcoded_response(response).with_default_timeout().await.unwrap();
 	let uri = format!("http://{server_addr}");
-	let client = HttpClientBuilder::default().build(&uri).unwrap();
+	let client = HttpClientBuilder::default().build(&uri).await.unwrap();
 	client.batch_request(batch).with_default_timeout().await.unwrap()
 }
 
 async fn run_request_with_response(response: String) -> Result<String, ClientError> {
 	let server_addr = http_server_with_hardcoded_response(response).with_default_timeout().await.unwrap();
 	let uri = format!("http://{server_addr}");
-	let client = HttpClientBuilder::default().build(&uri).unwrap();
+	let client = HttpClientBuilder::default().build(&uri).await.unwrap();
 	client.request("say_hello", rpc_params![]).with_default_timeout().await.unwrap()
 }
 

--- a/client/transport/Cargo.toml
+++ b/client/transport/Cargo.toml
@@ -38,6 +38,7 @@ rustls = { workspace = true, default-features = false, optional = true }
 
 # ws
 soketto = { workspace = true, optional = true }
+bytes = { workspace = true, optional = true }
 
 # web-sys
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -50,6 +51,7 @@ tls-rustls-platform-verifier = ["tls", "rustls-platform-verifier"]
 
 ws = [
     "base64",
+    "bytes",
     "futures-util",
     "http",
     "tokio",

--- a/client/transport/src/ws/mod.rs
+++ b/client/transport/src/ws/mod.rs
@@ -31,6 +31,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use base64::Engine;
+use bytes::Bytes;
 use futures_util::io::{BufReader, BufWriter};
 use jsonrpsee_core::Cow;
 use jsonrpsee_core::TEN_MB_SIZE_BYTES;
@@ -294,7 +295,7 @@ where
 					let s = String::from_utf8(message).map_err(|err| WsError::Connection(Utf8(err.utf8_error())))?;
 					Ok(ReceivedMessage::Text(s))
 				}
-				Incoming::Data(Data::Binary(_)) => Ok(ReceivedMessage::Bytes(message)),
+				Incoming::Data(Data::Binary(_)) => Ok(ReceivedMessage::Bytes(Bytes::from(message))),
 				Incoming::Pong(_) => Ok(ReceivedMessage::Pong),
 				Incoming::Closed(c) => Err(WsError::Closed(c)),
 			}

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -198,8 +198,8 @@ pub trait TransportSenderT: 'static {
 pub enum ReceivedMessage {
 	/// Incoming packet contains plain `String` data.
 	Text(String),
-	/// Incoming packet contains bytes.
-	Bytes(Vec<u8>),
+	/// Incoming packet contains bytes using zero-copy Bytes.
+	Bytes(bytes::Bytes),
 	/// Incoming `Pong` frame as a reply to a previously submitted `Ping` frame.
 	Pong,
 }

--- a/core/src/server/method_response.rs
+++ b/core/src/server/method_response.rs
@@ -33,6 +33,7 @@ use std::task::Poll;
 
 use crate::traits::ToJson;
 
+use bytes::{Bytes, BytesMut};
 use futures_util::{Future, FutureExt};
 use http::Extensions;
 use jsonrpsee_types::error::{
@@ -518,18 +519,25 @@ impl Future for MethodResponseFuture {
 #[derive(Debug, Clone)]
 struct BoundedWriter {
 	max_len: usize,
-	buf: Vec<u8>,
+	buf: BytesMut,
 }
 
 impl BoundedWriter {
 	/// Create a new bounded writer.
 	pub fn new(max_len: usize) -> Self {
-		Self { max_len, buf: Vec::with_capacity(128) }
+		Self { max_len, buf: BytesMut::with_capacity(128) }
 	}
 
 	/// Consume the writer and extract the written bytes.
+	/// Returns a Vec<u8> for backward compatibility.
 	pub fn into_bytes(self) -> Vec<u8> {
-		self.buf
+		self.buf.to_vec()
+	}
+
+	#[allow(dead_code)]
+	/// Consume the writer and extract the written bytes as Bytes.
+	pub fn into_bytes_zero_copy(self) -> Bytes {
+		self.buf.freeze()
 	}
 }
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,15 +7,20 @@ edition.workspace = true
 license.workspace = true
 publish = false
 
+[features]
+default = []
+http3 = ["jsonrpsee/http3"]
+
 [dev-dependencies]
 anyhow = { workspace = true }
+base64 = { workspace = true }
 http-body-util = { workspace = true }
 http-body = { workspace = true }
 futures = { workspace = true }
 jsonrpsee = { path = "../jsonrpsee", features = ["server", "http-client", "ws-client", "macros", "client-ws-transport-tls"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-tokio = { workspace = true, features = ["rt-multi-thread", "time"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "time", "signal"] }
 tokio-stream = { workspace = true, features = ["sync"] }
 serde_json = { workspace = true }
 tower-http = { workspace = true, features = ["cors", "compression-full", "sensitive-headers", "trace", "timeout"] }
@@ -23,3 +28,4 @@ tower = { workspace = true, features = ["timeout"] }
 hyper = { workspace = true }
 hyper-util = { workspace = true, features = ["client", "client-legacy"]}
 console-subscriber = { workspace = true }
+clap = { workspace = true, features = ["derive"] }

--- a/examples/examples/host_filter_middleware.rs
+++ b/examples/examples/host_filter_middleware.rs
@@ -48,7 +48,7 @@ async fn main() -> anyhow::Result<()> {
 	let url = format!("http://{}", addr);
 
 	// Use RPC client to get the response of `say_hello` method.
-	let client = HttpClient::builder().build(&url)?;
+	let client = HttpClient::builder().build(&url).await?;
 	// This call will be denied because only `example.com` URIs/hosts are allowed by the host filter.
 	let response = client.request::<String, _>("say_hello", rpc_params![]).await.unwrap_err();
 	println!("[main]: response: {}", response);

--- a/examples/examples/http.rs
+++ b/examples/examples/http.rs
@@ -41,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
 	let server_addr = run_server().await?;
 	let url = format!("http://{}", server_addr);
 
-	let client = HttpClient::builder().build(url)?;
+	let client = HttpClient::builder().build(url).await?;
 	let params = rpc_params![1_u64, 2, 3];
 	let response: Result<String, _> = client.request("say_hello", params).await;
 	tracing::info!("r: {:?}", response);

--- a/examples/examples/http3.rs
+++ b/examples/examples/http3.rs
@@ -1,0 +1,130 @@
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+
+use clap::Parser;
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::http_client::{CertificateVerificationMode, HttpClientBuilder};
+use jsonrpsee::rpc_params;
+use jsonrpsee::server::{RpcModule, ServerBuilder, ServerConfig};
+use jsonrpsee::types::ErrorObjectOwned;
+use tracing_subscriber::util::SubscriberInitExt;
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about = "HTTP/3 benchmark example for jsonrpsee")]
+struct Args {
+	#[clap(short = 'p', long, default_value = "27")]
+	payload_size: usize,
+
+	#[clap(short, long)]
+	url: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+	let args = Args::parse();
+
+	let filter = tracing_subscriber::EnvFilter::try_from_default_env()?
+		.add_directive("jsonrpsee[method_call{name = \"say_hello\"}]=trace".parse()?);
+	tracing_subscriber::FmtSubscriber::builder().with_env_filter(filter).finish().try_init()?;
+
+	let server_addr = match args.url {
+		Some(url) => {
+			// Ensure URL has http3:// scheme
+			if !url.starts_with("http3://") { format!("http3://{}", url) } else { url }
+		}
+		None => {
+			let addr = run_server().await?;
+			format!("http3://{}", addr)
+		}
+	};
+
+	tracing::info!("Using server URL: {}", server_addr);
+	tracing::info!("Payload size: {} elements", args.payload_size);
+
+	let client = HttpClientBuilder::default()
+		.enable_http3()
+		.with_http3_certificate_verification(CertificateVerificationMode::AcceptSelfSigned)
+		.build(&server_addr)
+		.await?;
+
+	let payload = vec![1_u64; args.payload_size];
+	let params = rpc_params![payload];
+
+	let start = Instant::now();
+	let response: Result<String, _> = client.request("say_hello", params.clone()).await;
+	let elapsed = start.elapsed();
+
+	match response {
+		Ok(result) => {
+			println!("Response: {}", result);
+			println!("Time: {:?}", elapsed);
+		}
+		Err(e) => {
+			eprintln!("Error: {:?}", e);
+		}
+	}
+
+	// Add a small delay
+	tokio::time::sleep(Duration::from_millis(500)).await;
+
+	// Send the 2nd request
+	println!("\nMaking a second request to verify server is still running...");
+	let start2 = Instant::now();
+	let response2: Result<String, _> = client.request("say_hello 222", params.clone()).await;
+	let elapsed2 = start2.elapsed();
+
+	match response2 {
+		Ok(result) => {
+			println!("Second response: {}", result);
+			println!("Time: {:?}", elapsed2);
+			println!("✅ Server is confirmed to be running in the background!");
+		}
+		Err(e) => {
+			eprintln!("Error on second request: {:?}", e);
+			eprintln!("❌ Server might not be running anymore.");
+		}
+	}
+
+	Ok(())
+}
+
+async fn run_server() -> anyhow::Result<SocketAddr> {
+	let http3_config = jsonrpsee::server::http3::Http3Config {
+		max_connections: 1000,
+		max_concurrent_requests_per_connection: 100,
+		max_idle_timeout: Duration::from_secs(30),
+		keep_alive_interval: Some(Duration::from_secs(5)),
+		enable_0rtt: true,
+		max_bidi_streams: 100,
+		max_uni_streams: 100,
+		initial_congestion_window: 14720,
+		enable_bbr: true,
+		cert_config: jsonrpsee::server::http3::CertificateConfig::SelfSigned { dns_name: "localhost".to_string() },
+	};
+
+	let config = ServerConfig::builder().enable_http3().with_http3_config(http3_config).build();
+	let server = ServerBuilder::default().set_config(config).build("127.0.0.1:34727".parse::<SocketAddr>()?).await?;
+
+	let mut module = RpcModule::new(());
+
+	module.register_method("say_hello", |params, _, _| -> Result<String, ErrorObjectOwned> {
+		let params: Vec<Vec<u64>> = params.parse()?;
+		let total_elements: usize = params.iter().map(|v| v.len()).sum();
+		Ok(format!("Received payload with {} elements", total_elements))
+	})?;
+
+	module.register_method("status", |_, _, _| -> Result<String, ErrorObjectOwned> {
+		Ok("Server is running".to_string())
+	})?;
+
+	let addr = server.local_addr()?;
+	tracing::info!("Server listening on {}", addr);
+
+	let handle = server.start(module);
+	tokio::spawn(async move {
+		handle.stopped().await;
+		println!("Server has stopped running");
+	});
+
+	Ok(addr)
+}

--- a/examples/examples/http_middleware.rs
+++ b/examples/examples/http_middleware.rs
@@ -73,7 +73,7 @@ async fn main() -> anyhow::Result<()> {
 
 	// HTTP.
 	{
-		let client = HttpClient::builder().build(format!("http://{}", addr))?;
+		let client = HttpClient::builder().build(format!("http://{}", addr)).await?;
 		let response: String = client.request("say_hello", rpc_params![]).await?;
 		println!("[main]: http response: {:?}", response);
 		let _response: Result<String, _> = client.request("unknown_method", rpc_params![]).await;

--- a/examples/examples/http_proxy_middleware.rs
+++ b/examples/examples/http_proxy_middleware.rs
@@ -61,7 +61,7 @@ async fn main() -> anyhow::Result<()> {
 	let url = format!("http://{}", addr);
 
 	// Use RPC client to get the response of `say_hello` method.
-	let client = HttpClient::builder().build(&url)?;
+	let client = HttpClient::builder().build(&url).await?;
 	let response: String = client.request("say_hello", rpc_params![]).await?;
 	println!("[main]: response: {:?}", response);
 

--- a/examples/examples/http_vs_http3.rs
+++ b/examples/examples/http_vs_http3.rs
@@ -4,10 +4,15 @@ use std::time::{Duration, Instant};
 
 use clap::Parser;
 use jsonrpsee::core::client::ClientT;
-use jsonrpsee::http_client::{CertificateVerificationMode, HttpClientBuilder};
+use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::rpc_params;
-use jsonrpsee::server::{RpcModule, ServerBuilder, ServerConfig};
+use jsonrpsee::server::{RpcModule, ServerBuilder};
 use jsonrpsee::types::ErrorObjectOwned;
+
+#[cfg(feature = "http3")]
+use jsonrpsee::http_client::CertificateVerificationMode;
+#[cfg(feature = "http3")]
+use jsonrpsee::server::ServerConfig;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]

--- a/examples/examples/http_vs_http3.rs
+++ b/examples/examples/http_vs_http3.rs
@@ -1,0 +1,234 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use clap::Parser;
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::http_client::{CertificateVerificationMode, HttpClientBuilder};
+use jsonrpsee::rpc_params;
+use jsonrpsee::server::{RpcModule, ServerBuilder, ServerConfig};
+use jsonrpsee::types::ErrorObjectOwned;
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+	#[clap(short = 't', long, default_value = "http")]
+	protocol: String,
+
+	#[clap(short = 'p', long, default_value = "27")]
+	payload_size: usize,
+
+	#[clap(short, long, default_value = "100")]
+	requests: usize,
+
+	#[clap(short, long, default_value = "10")]
+	connections: usize,
+
+	#[clap(short, long)]
+	url: Option<String>,
+
+	#[clap(short, long)]
+	server: bool,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+	let args = Args::parse();
+
+	if std::env::var("RUST_LOG").is_err() {
+		unsafe {
+			std::env::set_var("RUST_LOG", "info");
+		}
+	}
+	tracing_subscriber::fmt::init();
+
+	if args.server {
+		let server_addr = run_server(args.protocol == "http3").await?;
+		tracing::info!("Server listening on {}", server_addr);
+
+		tokio::signal::ctrl_c().await?;
+		return Ok(());
+	}
+
+	let server_url = match args.url {
+		Some(url) => url,
+		None => {
+			let server_addr = run_server(args.protocol == "http3").await?;
+			match args.protocol.as_str() {
+				"http" => format!("http://{}", server_addr),
+				"http3" => format!("http3://{}", server_addr),
+				_ => return Err(anyhow::anyhow!("Invalid protocol: {}", args.protocol)),
+			}
+		}
+	};
+
+	if server_url.contains("127.0.0.1:0") {
+		return Err(anyhow::anyhow!("Invalid server address: {}", server_url));
+	}
+
+	tracing::info!("Using server URL: {}", server_url);
+	tracing::info!("Protocol: {}", args.protocol);
+	tracing::info!("Payload size: {} elements", args.payload_size);
+	tracing::info!("Requests: {}", args.requests);
+	tracing::info!("Connections: {}", args.connections);
+
+	let mut clients = Vec::with_capacity(args.connections);
+	for _ in 0..args.connections {
+		let client = if args.protocol == "http3" {
+			#[cfg(feature = "http3")]
+			{
+				tracing::info!("Creating HTTP/3 client with URL: {}", server_url);
+				let builder = HttpClientBuilder::default();
+				let client = builder
+					.enable_http3()
+					.with_http3_certificate_verification(CertificateVerificationMode::AcceptSelfSigned)
+					.build(&server_url)
+					.await?;
+				tracing::info!("HTTP/3 client created successfully");
+				client
+			}
+			#[cfg(not(feature = "http3"))]
+			{
+				return Err(anyhow::anyhow!("HTTP/3 support not enabled. Compile with --features http3"));
+			}
+		} else {
+			tracing::info!("Creating HTTP client with URL: {}", server_url);
+			let client = HttpClientBuilder::default().build(&server_url).await?;
+			tracing::info!("HTTP client created successfully");
+			client
+		};
+		clients.push(Arc::new(client));
+	}
+
+	let payload = vec![1_u64; args.payload_size];
+
+	let start = Instant::now();
+	let mut handles = Vec::with_capacity(args.requests);
+
+	for i in 0..args.requests {
+		let client = clients[i % args.connections].clone();
+		let payload = payload.clone();
+
+		let handle = tokio::spawn(async move {
+			let params = rpc_params![payload];
+			let start = Instant::now();
+			let response: Result<String, _> = client.request("benchmark", params).await;
+			let elapsed = start.elapsed();
+
+			match response {
+				Ok(_) => (true, elapsed),
+				Err(e) => {
+					tracing::error!("Request failed: {:?}", e);
+					(false, elapsed)
+				}
+			}
+		});
+
+		handles.push(handle);
+	}
+
+	let mut results = Vec::with_capacity(args.requests);
+	for handle in handles {
+		results.push(handle.await?);
+	}
+
+	let total_elapsed = start.elapsed();
+	let successful = results.iter().filter(|(success, _)| *success).count();
+	let total_requests = results.len();
+
+	let mut latencies: Vec<Duration> = results.into_iter().map(|(_, elapsed)| elapsed).collect();
+	latencies.sort();
+
+	let avg_latency = if !latencies.is_empty() {
+		latencies.iter().sum::<Duration>() / latencies.len() as u32
+	} else {
+		Duration::ZERO
+	};
+
+	let min_latency = latencies.first().unwrap_or(&Duration::ZERO);
+	let max_latency = latencies.last().unwrap_or(&Duration::ZERO);
+	let median_latency = if !latencies.is_empty() { latencies[latencies.len() / 2] } else { Duration::ZERO };
+
+	let p95_latency =
+		if !latencies.is_empty() { latencies[(latencies.len() as f64 * 0.95) as usize] } else { Duration::ZERO };
+
+	let p99_latency =
+		if !latencies.is_empty() { latencies[(latencies.len() as f64 * 0.99) as usize] } else { Duration::ZERO };
+
+	let requests_per_second =
+		if total_elapsed.as_secs_f64() > 0.0 { total_requests as f64 / total_elapsed.as_secs_f64() } else { 0.0 };
+
+	println!("\n=== Benchmark Results ===");
+	println!("Protocol:           {}", args.protocol);
+	println!("Payload size:       {} elements", args.payload_size);
+	println!("Total requests:     {}", total_requests);
+	println!(
+		"Successful:         {} ({}%)",
+		successful,
+		if total_requests > 0 { (successful as f64 / total_requests as f64) * 100.0 } else { 0.0 }
+	);
+	println!("Total time:         {:.2?}", total_elapsed);
+	println!("Requests/second:    {:.2}", requests_per_second);
+	println!("Average latency:    {:.2?}", avg_latency);
+	println!("Minimum latency:    {:.2?}", min_latency);
+	println!("Maximum latency:    {:.2?}", max_latency);
+	println!("Median latency:     {:.2?}", median_latency);
+	println!("95th percentile:    {:.2?}", p95_latency);
+	println!("99th percentile:    {:.2?}", p99_latency);
+
+	Ok(())
+}
+
+async fn run_server(use_http3: bool) -> anyhow::Result<SocketAddr> {
+	let port = match std::env::var("SERVER_PORT") {
+		Ok(port) => port.parse::<u16>()?,
+		Err(_) => 0, // Use random port if not specified
+	};
+
+	let addr = format!("127.0.0.1:{}", port).parse::<SocketAddr>()?;
+
+	let server = if use_http3 {
+		#[cfg(feature = "http3")]
+		{
+			let http3_config = jsonrpsee::server::http3::Http3Config {
+				max_connections: 1000,
+				max_concurrent_requests_per_connection: 100,
+				max_idle_timeout: Duration::from_secs(30),
+				keep_alive_interval: Some(Duration::from_secs(5)),
+				enable_0rtt: true,
+				max_bidi_streams: 100,
+				max_uni_streams: 100,
+				initial_congestion_window: 14720,
+				enable_bbr: true,
+				cert_config: jsonrpsee::server::http3::CertificateConfig::SelfSigned {
+					dns_name: "localhost".to_string(),
+				},
+			};
+
+			let config = ServerConfig::builder().enable_http3().with_http3_config(http3_config).build();
+
+			ServerBuilder::default().set_config(config).build(addr).await?
+		}
+		#[cfg(not(feature = "http3"))]
+		{
+			return Err(anyhow::anyhow!("HTTP/3 support not enabled. Compile with --features http3"));
+		}
+	} else {
+		ServerBuilder::default().build(addr).await?
+	};
+	let mut module = RpcModule::new(());
+
+	module.register_method("benchmark", |params, _, _| -> Result<String, ErrorObjectOwned> {
+		let params: Vec<Vec<u64>> = params.parse()?;
+		let total_elements: usize = params.iter().map(|v| v.len()).sum();
+		Ok(format!("Processed payload with {} elements", total_elements))
+	})?;
+
+	let addr = server.local_addr()?;
+	tracing::info!("Server listening on {}", addr);
+
+	let handle = server.start(module);
+	tokio::spawn(handle.stopped());
+
+	Ok(addr)
+}

--- a/examples/examples/jsonrpsee_as_service.rs
+++ b/examples/examples/jsonrpsee_as_service.rs
@@ -228,7 +228,7 @@ async fn main() -> anyhow::Result<()> {
 	tokio::spawn(handle.stopped());
 
 	{
-		let client = HttpClient::builder().build("http://127.0.0.1:9944").unwrap();
+		let client = HttpClient::builder().build("http://127.0.0.1:9944").await.unwrap();
 
 		// Fails because the authorization header is missing.
 		let x = client.trusted_call().await.unwrap_err();
@@ -247,7 +247,7 @@ async fn main() -> anyhow::Result<()> {
 		let mut headers = HeaderMap::new();
 		headers.insert(AUTHORIZATION, HeaderValue::from_static("don't care in this example"));
 
-		let client = HttpClient::builder().set_headers(headers).build("http://127.0.0.1:9944").unwrap();
+		let client = HttpClient::builder().set_headers(headers).build("http://127.0.0.1:9944").await.unwrap();
 
 		let x = client.trusted_call().await.unwrap();
 		tracing::info!("response: {x}");

--- a/examples/examples/jsonrpsee_server_low_level_api.rs
+++ b/examples/examples/jsonrpsee_server_low_level_api.rs
@@ -180,7 +180,7 @@ async fn main() -> anyhow::Result<()> {
 		let mut i = 0;
 		let handle = run_server().await?;
 
-		let client = HttpClient::builder().build("http://127.0.0.1:9944").unwrap();
+		let client = HttpClient::builder().build("http://127.0.0.1:9944").await.unwrap();
 		while client.say_hello().await.is_ok() {
 			i += 1;
 		}

--- a/jsonrpsee/Cargo.toml
+++ b/jsonrpsee/Cargo.toml
@@ -40,6 +40,7 @@ http-client = ["jsonrpsee-http-client", "jsonrpsee-types", "jsonrpsee-core/clien
 wasm-client = ["jsonrpsee-wasm-client", "jsonrpsee-types", "jsonrpsee-core/client"]
 ws-client = ["jsonrpsee-ws-client", "jsonrpsee-types", "jsonrpsee-core/client"]
 macros = ["jsonrpsee-proc-macros", "jsonrpsee-types", "tracing"]
+http3 = ["jsonrpsee-http-client/http3", "jsonrpsee-server/http3"]
 
 client = ["http-client", "ws-client", "wasm-client", "client-ws-transport-tls", "client-web-transport", "async-client", "async-wasm-client", "client-core"]
 client-core = ["jsonrpsee-core/client"]

--- a/scripts/bench_http.sh
+++ b/scripts/bench_http.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+
+set -e
+
+if ! command -v hyperfine &> /dev/null; then
+    echo "hyperfine is not installed. Please install it first:"
+    echo "cargo install --locked hyperfine"
+    exit 1
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo "jq is not installed. Please install it first:"
+    echo "apt-get install jq"   # For Debian/Ubuntu
+    exit 1
+fi
+
+echo "Building examples..."
+cd "$(dirname "$0")/.."
+cargo build --release --example http_vs_http3 --features http3
+
+PAYLOAD_SIZES=(3 9 27 81 243)
+RESULTS_DIR="benchmark_results"
+mkdir -p "$RESULTS_DIR"
+
+echo "Increasing file descriptor limits..."
+ulimit -n 100000 || echo "Warning: Failed to increase file descriptor limits. Benchmarks may fail."
+
+clear_cache() {
+    echo "Clearing OS cache..."
+    if [ "$(uname)" = "Linux" ]; then
+        if command -v sudo &> /dev/null && sudo -n true 2>/dev/null; then
+            sudo sh -c "echo 3 > /proc/sys/vm/drop_caches"
+        else
+            echo "Warning: Cannot clear OS cache (need sudo). Results may be affected by caching."
+        fi
+    elif [ "$(uname)" = "Darwin" ]; then
+        if command -v sudo &> /dev/null && sudo -n true 2>/dev/null; then
+            sudo purge
+        else
+            echo "Warning: Cannot clear OS cache (need sudo). Results may be affected by caching."
+        fi
+    else
+        echo "Warning: Unsupported OS for cache clearing. Results may be affected by caching."
+    fi
+}
+
+run_benchmark() {
+    local size=$1
+    local runs=${2:-20}
+    local warmup=${3:-5}
+
+    echo "Benchmarking with payload size: $size elements"
+
+    clear_cache
+
+    HTTP_PORT=$(( 9000 + RANDOM % 1000 ))
+    HTTP3_PORT=$(( 10000 + RANDOM % 1000 ))
+
+    pkill -f "http_vs_http3.*-s" || true
+    sleep 2
+
+    # Create temp directory for logs
+    TEMP_DIR=$(mktemp -d)
+    HTTP_LOG="$TEMP_DIR/http_server.log"
+    HTTP3_LOG="$TEMP_DIR/http3_server.log"
+
+    echo "Starting HTTP server on port $HTTP_PORT..."
+    SERVER_PORT=$HTTP_PORT RUST_LOG=info cargo run --release --example http_vs_http3 -- -t http -p "$size" -s > "$HTTP_LOG" 2>&1 &
+    HTTP_PID=$!
+
+    # Increased timeout to 60 seconds
+    for i in {1..60}; do
+        if grep -q "Server listening on" "$HTTP_LOG"; then
+            echo "HTTP server started successfully"
+            break
+        fi
+        if [ $i -eq 60 ]; then
+            echo "Timed out waiting for HTTP server to start"
+            cat "$HTTP_LOG"
+            kill $HTTP_PID 2>/dev/null || true
+            rm -rf "$TEMP_DIR"
+            exit 1
+        fi
+        sleep 1
+    done
+
+    echo "Starting HTTP/3 server on port $HTTP3_PORT..."
+    SERVER_PORT=$HTTP3_PORT RUST_LOG=info cargo run --release --features http3 --example http_vs_http3 -- -t http3 -p "$size" -s > "$HTTP3_LOG" 2>&1 &
+    HTTP3_PID=$!
+
+    # Increased timeout to 60 seconds
+    for i in {1..60}; do
+        if grep -q "Server listening on" "$HTTP3_LOG"; then
+            echo "HTTP/3 server started successfully"
+            break
+        fi
+        if [ $i -eq 60 ]; then
+            echo "Timed out waiting for HTTP/3 server to start"
+            cat "$HTTP3_LOG"
+            kill $HTTP_PID $HTTP3_PID 2>/dev/null || true
+            rm -rf "$TEMP_DIR"
+            exit 1
+        fi
+        sleep 1
+    done
+
+    HTTP_ADDR=$(grep -o "Server listening on [0-9.]*:[0-9]*" "$HTTP_LOG" | head -1 | awk '{print $4}')
+    HTTP3_ADDR=$(grep -o "Server listening on [0-9.]*:[0-9]*" "$HTTP3_LOG" | head -1 | awk '{print $4}')
+
+    if [ -z "$HTTP_ADDR" ] || [ -z "$HTTP3_ADDR" ]; then
+        echo "Failed to capture server addresses:"
+        echo "HTTP log:"
+        cat "$HTTP_LOG"
+        echo "HTTP3 log:"
+        cat "$HTTP3_LOG"
+        kill $HTTP_PID $HTTP3_PID 2>/dev/null || true
+        rm -rf "$TEMP_DIR"
+        exit 1
+    fi
+
+    echo "HTTP server address: $HTTP_ADDR"
+    echo "HTTP/3 server address: $HTTP3_ADDR"
+
+    prepare_cmd="sleep 0.5 && $([ "$(uname)" = "Linux" ] && echo "sync" || echo "true")"
+
+    echo "Running benchmarks with payload size: $size elements"
+    echo "HTTP URL: http://$HTTP_ADDR"
+    echo "HTTP/3 URL: http3://$HTTP3_ADDR"
+
+    echo "Testing HTTP client..."
+    if ! RUST_LOG=info timeout 30s cargo run --release --example http_vs_http3 -- -t http -p $size -r 1 -c 1 -u http://$HTTP_ADDR; then
+        echo "Warning: HTTP client test failed. Skipping benchmarks for this payload size."
+        kill $HTTP_PID $HTTP3_PID 2>/dev/null || true
+        rm -rf "$TEMP_DIR"
+        return 1
+    fi
+
+    echo "Testing HTTP/3 client..."
+    if ! RUST_LOG=info timeout 30s cargo run --release --features http3 --example http_vs_http3 -- -t http3 -p $size -r 1 -c 1 -u http3://$HTTP3_ADDR; then
+        echo "Warning: HTTP/3 client test failed. This may be due to QUIC protocol issues in the current environment."
+        echo "Continuing with HTTP-only benchmark."
+
+        hyperfine \
+            --warmup "$warmup" \
+            --runs "$runs" \
+            --export-json "$RESULTS_DIR/payload_${size}.json" \
+            --prepare "$prepare_cmd" \
+            --time-unit millisecond \
+            "env RUST_LOG=info timeout 30s cargo run --release --example http_vs_http3 -- -t http -p $size -r 100 -c 10 -u http://$HTTP_ADDR"
+    else
+        hyperfine \
+            --warmup "$warmup" \
+            --runs "$runs" \
+            --export-json "$RESULTS_DIR/payload_${size}.json" \
+            --prepare "$prepare_cmd" \
+            --time-unit millisecond \
+            "env RUST_LOG=info timeout 30s cargo run --release --example http_vs_http3 -- -t http -p $size -r 100 -c 10 -u http://$HTTP_ADDR" \
+            "env RUST_LOG=info timeout 30s cargo run --release --features http3 --example http_vs_http3 -- -t http3 -p $size -r 100 -c 10 -u http3://$HTTP3_ADDR"
+    fi
+
+    if [ -f "$RESULTS_DIR/payload_${size}.json" ]; then
+        HTTP_TIME=$(jq '.results[0].mean' "$RESULTS_DIR/payload_${size}.json")
+        HTTP3_TIME=$(jq '.results[1].mean' "$RESULTS_DIR/payload_${size}.json" 2>/dev/null || echo "null")
+
+        if [ "$HTTP3_TIME" != "null" ]; then
+            IMPROVEMENT=$(echo "scale=2; (($HTTP_TIME - $HTTP3_TIME) / $HTTP_TIME) * 100" | bc)
+            echo "HTTP/3 improvement for ${size} elements: ${IMPROVEMENT}%"
+        else
+            echo "HTTP/3 benchmark failed for ${size} elements. No comparison available."
+        fi
+    else
+        echo "Benchmark results file not found for ${size} elements."
+    fi
+
+    echo "Stopping servers..."
+    kill $HTTP_PID $HTTP3_PID 2>/dev/null || true
+    wait $HTTP_PID $HTTP3_PID 2>/dev/null || true
+    sleep 1
+
+    rm -rf "$TEMP_DIR"
+    clear_cache
+}
+
+for size in "${PAYLOAD_SIZES[@]}"; do
+    run_benchmark "$size"
+done
+
+echo "Generating summary report..."
+echo "# HTTP/3 Performance Benchmark Results" > "$RESULTS_DIR/summary.md"
+echo "" >> "$RESULTS_DIR/summary.md"
+echo "| Payload Size | HTTP/1.1 Mean (ms) | HTTP/3 Mean (ms) | Improvement (%) |" >> "$RESULTS_DIR/summary.md"
+echo "|-------------|-----------------|---------------|---------------|" >> "$RESULTS_DIR/summary.md"
+
+for size in "${PAYLOAD_SIZES[@]}"; do
+    if [ -f "$RESULTS_DIR/payload_${size}.json" ]; then
+        HTTP_TIME=$(jq '.results[0].mean' "$RESULTS_DIR/payload_${size}.json" 2>/dev/null || echo "N/A")
+        HTTP3_TIME=$(jq '.results[1].mean' "$RESULTS_DIR/payload_${size}.json" 2>/dev/null || echo "N/A")
+
+        if [ "$HTTP_TIME" != "N/A" ] && [ "$HTTP3_TIME" != "N/A" ]; then
+            IMPROVEMENT=$(echo "scale=2; (($HTTP_TIME - $HTTP3_TIME) / $HTTP_TIME) * 100" | bc 2>/dev/null || echo "N/A")
+            echo "| ${size} elements | ${HTTP_TIME} | ${HTTP3_TIME} | ${IMPROVEMENT}% |" >> "$RESULTS_DIR/summary.md"
+        else
+            echo "| ${size} elements | ${HTTP_TIME} | ${HTTP3_TIME} | N/A |" >> "$RESULTS_DIR/summary.md"
+        fi
+    else
+        echo "| ${size} elements | N/A | N/A | N/A |" >> "$RESULTS_DIR/summary.md"
+    fi
+done
+
+echo ""
+echo "Benchmark complete! Results saved to $RESULTS_DIR/summary.md"
+echo "To view the summary: cat $RESULTS_DIR/summary.md"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,25 +17,36 @@ publish = true
 workspace = true
 
 [dependencies]
+bytes = { workspace = true }
 futures-util = { workspace = true, features = ["io", "async-await-macro"] }
 http = { workspace = true }
+h3 = { workspace = true, optional = true }
+h3-quinn = { workspace = true, optional = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["server", "http1", "http2"] }
 hyper-util = { workspace = true, features = ["tokio", "service", "tokio", "server-auto"] }
 jsonrpsee-core = { workspace = true, features = ["server", "http-helpers"] }
 jsonrpsee-types = { workspace = true }
+quinn = { workspace = true, optional = true }
+rcgen = { workspace = true, optional = true }
 pin-project = "1.1.3"
 route-recognizer = "0.3.1"
 serde = "1"
 serde_json = { version = "1", features = ["raw_value"] }
 soketto = { version = "0.8.1", features = ["http"] }
 thiserror = "2"
+rand = { workspace = true }
+rustls = { workspace = true, optional = true }
+rustls-pemfile = { workspace = true, optional = true }
 tokio = { version = "1.23.1", features = ["net", "rt-multi-thread", "macros", "time"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tokio-stream = { version = "0.1.7", features = ["sync"] }
 tower = { workspace = true, features = ["util"] }
 tracing = { workspace = true }
+
+[features]
+http3 = ["h3", "h3-quinn", "quinn", "rcgen", "rustls", "rustls-pemfile"]
 
 [dev-dependencies]
 jsonrpsee-test-utils = { path = "../test-utils" }

--- a/server/src/future.rs
+++ b/server/src/future.rs
@@ -59,6 +59,12 @@ impl StopHandle {
 	pub async fn shutdown(mut self) {
 		let _ = self.0.changed().await;
 	}
+
+	/// Check if the server has been stopped.
+	pub fn is_stopped(&self) -> bool {
+		// The receiver has changed from its initial state when stop is called
+		self.0.has_changed().unwrap_or(true)
+	}
 }
 
 /// Error when the server has already been stopped.

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -24,12 +24,27 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+// #![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # jsonrpsee-server
 //!
 //! `jsonrpsee-server` is a [JSON RPC](https://www.jsonrpc.org/specification) server that supports both HTTP and WebSocket transport.
 
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#[cfg(feature = "http3")]
+use h3 as _;
+#[cfg(feature = "http3")]
+use h3_quinn as _;
+#[cfg(feature = "http3")]
+use quinn as _;
+#[cfg(feature = "http3")]
+use rcgen as _;
+
+#[cfg(feature = "http3")]
+/// Module containing HTTP/3 server types and configuration.
+pub mod http3 {
+	pub use crate::transport::http3::{CertificateConfig, Http3Config, Http3Server};
+}
 
 mod future;
 mod server;

--- a/server/src/middleware/http/authority.rs
+++ b/server/src/middleware/http/authority.rs
@@ -153,6 +153,7 @@ fn default_port(scheme: Option<&str>) -> Option<u16> {
 		Some("http") | Some("ws") => Some(80),
 		Some("https") | Some("wss") => Some(443),
 		Some("ftp") => Some(21),
+		Some("http3") => Some(443),
 		_ => None,
 	}
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -142,19 +142,16 @@ where
 			let server_cfg = self.server_cfg.clone();
 			let http3_methods = methods.clone();
 
-			// Create a service builder function that creates a new service for each connection
 			let service_builder = move |conn_state: ConnectionState| {
 				let methods = http3_methods.clone();
 				let server_cfg = server_cfg.clone();
 
-				// Create a tower service function that handles the request
 				tower::service_fn(move |req: HttpRequest| {
 					let methods = methods.clone();
 					let server_cfg = server_cfg.clone();
 					let conn_id = conn_state.conn_id;
 
 					async move {
-						// Create a proper RPC service
 						let rpc_service = RpcService::new(
 							methods,
 							server_cfg.max_response_body_size as usize,
@@ -162,7 +159,6 @@ where
 							RpcServiceCfg::OnlyCalls,
 						);
 
-						// Use the existing HTTP transport module to handle the request
 						let response = crate::transport::http::call_with_service(
 							req,
 							server_cfg.batch_requests_config,
@@ -176,7 +172,6 @@ where
 				})
 			};
 
-			// Start the HTTP/3 server
 			http3_server
 				.start(
 					service_builder,
@@ -224,6 +219,7 @@ where
 		}
 	}
 }
+
 /// Static server configuration which is shared per connection.
 #[derive(Debug, Clone)]
 pub struct ServerConfig {
@@ -245,7 +241,6 @@ pub struct ServerConfig {
 	pub(crate) enable_ws: bool,
 	/// Enable HTTP/3.
 	#[cfg(feature = "http3")]
-	#[allow(dead_code)]
 	pub(crate) enable_http3: bool,
 	/// HTTP/3 configuration.
 	#[cfg(feature = "http3")]

--- a/server/src/transport/http3.rs
+++ b/server/src/transport/http3.rs
@@ -1,0 +1,463 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::{Buf, Bytes};
+// use futures_util::StreamExt;
+use h3::server::{Connection, RequestStream};
+use h3_quinn::{Connection as H3Connection, quinn};
+use http::{Request, Response, StatusCode};
+// use http_body_util::Full;
+use jsonrpsee_core::BoxError;
+use jsonrpsee_core::server::Methods;
+use quinn::crypto::rustls::QuicServerConfig;
+use quinn::{Endpoint, ServerConfig as QuinnServerConfig, TransportConfig, VarInt};
+use rustls::ServerConfig as RustlsServerConfig;
+use tokio::sync::Semaphore;
+use tower::Service;
+use tracing::{debug, error, info, trace};
+
+use crate::{
+	ConnectionGuard, ConnectionState, HttpBody, HttpRequest, HttpResponse, LOG_TARGET, ServerConfig, StopHandle,
+};
+
+/// HTTP/3 server configuration
+#[derive(Debug, Clone)]
+pub struct Http3Config {
+	/// Maximum number of concurrent connections
+	pub max_connections: usize,
+	/// Maximum number of concurrent requests per connection
+	pub max_concurrent_requests_per_connection: usize,
+	/// Maximum idle timeout for connections
+	pub max_idle_timeout: Duration,
+	/// Keep-alive interval
+	pub keep_alive_interval: Option<Duration>,
+	/// Enable 0-RTT
+	pub enable_0rtt: bool,
+	/// Maximum number of bidirectional streams
+	pub max_bidi_streams: u32,
+	/// Maximum number of unidirectional streams
+	pub max_uni_streams: u32,
+	/// Initial congestion window
+	pub initial_congestion_window: u32,
+	/// Enable BBR congestion control
+	pub enable_bbr: bool,
+	/// Certificate configuration
+	pub cert_config: CertificateConfig,
+}
+
+/// Certificate configuration for HTTP/3
+#[derive(Debug, Clone)]
+pub enum CertificateConfig {
+	/// Use a self-signed certificate (for testing)
+	SelfSigned {
+		/// DNS name for the certificate
+		dns_name: String,
+	},
+	/// Use provided certificate and key
+	Custom {
+		/// Certificate chain in PEM format
+		cert_chain: Vec<u8>,
+		/// Private key in PEM format
+		private_key: Vec<u8>,
+	},
+}
+
+impl Default for Http3Config {
+	fn default() -> Self {
+		Self {
+			max_connections: 1000,
+			max_concurrent_requests_per_connection: 100,
+			max_idle_timeout: Duration::from_secs(30),
+			keep_alive_interval: Some(Duration::from_secs(5)),
+			enable_0rtt: true,
+			max_bidi_streams: 100,
+			max_uni_streams: 100,
+			initial_congestion_window: 14720, // ~10 packets
+			enable_bbr: true,
+			cert_config: CertificateConfig::SelfSigned { dns_name: "localhost".to_string() },
+		}
+	}
+}
+
+#[derive(Debug)]
+/// HTTP/3 server handle
+pub struct Http3Server {
+	endpoint: Endpoint,
+	local_addr: SocketAddr,
+}
+
+impl Http3Server {
+	/// Create a new HTTP/3 server
+	pub async fn new(addr: SocketAddr, config: Http3Config) -> Result<Self, BoxError> {
+		// Create TLS configuration
+		let tls_config = create_tls_config(&config.cert_config)?;
+
+		// Create QUIC transport configuration
+		let mut transport_config = TransportConfig::default();
+		transport_config.max_concurrent_bidi_streams(VarInt::from_u32(config.max_bidi_streams));
+		transport_config.max_concurrent_uni_streams(VarInt::from_u32(config.max_uni_streams));
+		transport_config.max_idle_timeout(Some(config.max_idle_timeout.try_into().unwrap()));
+
+		if let Some(interval) = config.keep_alive_interval {
+			transport_config.keep_alive_interval(Some(interval));
+		}
+
+		if config.enable_bbr {
+			transport_config.congestion_controller_factory(Arc::new(quinn::congestion::BbrConfig::default()));
+		}
+
+		// Create server configuration
+		let quic_config = QuicServerConfig::try_from(tls_config)?;
+		let mut server_config = QuinnServerConfig::with_crypto(Arc::new(quic_config));
+		server_config.transport_config(Arc::new(transport_config));
+
+		if config.enable_0rtt {
+			server_config.retry_token_lifetime(Duration::from_secs(3600));
+		}
+
+		// Create endpoint
+		let endpoint = Endpoint::server(server_config, addr)?;
+		let local_addr = endpoint.local_addr()?;
+
+		info!(target: LOG_TARGET, "HTTP/3 server listening on {}", local_addr);
+
+		Ok(Self { endpoint, local_addr })
+	}
+
+	/// Get the local address the server is bound to
+	pub fn local_addr(&self) -> SocketAddr {
+		self.local_addr
+	}
+
+	/// Start accepting connections
+	pub async fn start<S, Svc>(
+		self,
+		service_builder: S,
+		methods: Methods,
+		server_cfg: ServerConfig,
+		conn_guard: ConnectionGuard,
+		stop_handle: StopHandle,
+	) where
+		S: Fn(ConnectionState) -> Svc + Send + Sync + 'static + Clone,
+		Svc: Service<HttpRequest, Response = HttpResponse, Error = BoxError> + Send + 'static + Clone,
+		Svc::Future: Send + 'static,
+	{
+		let max_concurrent_requests = Arc::new(Semaphore::new(server_cfg.max_connections as usize));
+
+		tokio::spawn(async move {
+			accept_loop(
+				self.endpoint,
+				service_builder,
+				methods,
+				server_cfg,
+				conn_guard,
+				stop_handle,
+				max_concurrent_requests,
+			)
+			.await;
+		});
+	}
+}
+
+/// Main accept loop for HTTP/3 connections
+async fn accept_loop<S, Svc>(
+	endpoint: Endpoint,
+	service_builder: S,
+	methods: Methods,
+	server_cfg: ServerConfig,
+	conn_guard: ConnectionGuard,
+	stop_handle: StopHandle,
+	max_concurrent_requests: Arc<Semaphore>,
+) where
+	S: Fn(ConnectionState) -> Svc + Send + Sync + 'static + Clone,
+	Svc: Service<HttpRequest, Response = HttpResponse, Error = BoxError> + Send + 'static + Clone,
+	Svc::Future: Send + 'static,
+{
+	let stopped = stop_handle.clone().shutdown();
+	tokio::pin!(stopped);
+
+	loop {
+		let incoming = tokio::select! {
+			Some(incoming) = endpoint.accept() => incoming,
+			_ = &mut stopped => break,
+		};
+
+		let remote_addr = incoming.remote_address();
+		debug!(target: LOG_TARGET, "New HTTP/3 connection from {}", remote_addr);
+
+		let conn_permit = match conn_guard.try_acquire() {
+			Some(permit) => permit,
+			None => {
+				debug!(target: LOG_TARGET, "Max connections reached, rejecting connection from {}", remote_addr);
+				continue;
+			}
+		};
+
+		let conn_id = rand::random::<u32>();
+		let conn_state = ConnectionState::new(stop_handle.clone(), conn_id, conn_permit);
+		let service = service_builder(conn_state.clone());
+
+		let methods = methods.clone();
+		let server_cfg = server_cfg.clone();
+		let max_concurrent_requests = max_concurrent_requests.clone();
+		let stop_handle = stop_handle.clone();
+
+		tokio::spawn(async move {
+			// Accept the connection
+			let connection = match incoming.await {
+				Ok(conn) => conn,
+				Err(e) => {
+					debug!(target: LOG_TARGET, "Failed to accept HTTP/3 connection: {}", e);
+					return;
+				}
+			};
+
+			if let Err(e) = handle_connection(
+				connection,
+				service,
+				methods,
+				server_cfg,
+				conn_state,
+				max_concurrent_requests,
+				stop_handle,
+			)
+			.await
+			{
+				debug!(target: LOG_TARGET, "HTTP/3 connection error: {}", e);
+			}
+		});
+	}
+
+	info!(target: LOG_TARGET, "HTTP/3 server stopped");
+}
+
+/// Handle a single HTTP/3 connection
+async fn handle_connection<Svc>(
+	connection: quinn::Connection,
+	service: Svc,
+	methods: Methods,
+	server_cfg: ServerConfig,
+	conn_state: ConnectionState,
+	max_concurrent_requests: Arc<Semaphore>,
+	stop_handle: StopHandle,
+) -> Result<(), BoxError>
+where
+	Svc: Service<HttpRequest, Response = HttpResponse, Error = BoxError> + Send + 'static + Clone,
+	Svc::Future: Send + 'static,
+{
+	let h3_conn = H3Connection::new(connection);
+
+	let mut h3: Connection<_, Bytes> = h3::server::Connection::new(h3_conn).await?;
+
+	trace!(target: LOG_TARGET, "HTTP/3 connection established");
+
+	let stopped = stop_handle.clone().shutdown();
+	tokio::pin!(stopped);
+
+	loop {
+		let request_stream = tokio::select! {
+			result = h3.accept() => {
+				match result {
+					Ok(Some(req)) => req,
+					Ok(None) => break,
+					Err(e) => {
+						debug!(target: LOG_TARGET, "Error accepting HTTP/3 request: {}", e);
+						break;
+					}
+				}
+			}
+			_ = &mut stopped => break,
+		};
+
+		let permit = match max_concurrent_requests.clone().try_acquire_owned() {
+			Ok(p) => p,
+			Err(_) => {
+				debug!(target: LOG_TARGET, "Max concurrent requests reached");
+				// We need to properly reject this request
+				continue;
+			}
+		};
+
+		let service = service.clone();
+		let methods = methods.clone();
+		let server_cfg = server_cfg.clone();
+		let conn_state = conn_state.clone();
+
+		tokio::spawn(async move {
+			let _permit = permit; // Keep permit alive for the duration
+
+			// Get the request from the resolver
+			if let Ok((request, stream)) = request_stream.resolve_request().await {
+				if let Err(e) = handle_request(request, stream, service, methods, server_cfg, conn_state).await {
+					error!(target: LOG_TARGET, "Error handling HTTP/3 request: {}", e);
+				}
+			}
+		});
+	}
+
+	Ok(())
+}
+/// Handle a single HTTP/3 request
+async fn handle_request<Svc, S>(
+	request: Request<()>,
+	mut stream: RequestStream<S, Bytes>,
+	mut service: Svc,
+	methods: Methods,
+	server_cfg: ServerConfig,
+	conn_state: ConnectionState,
+) -> Result<(), BoxError>
+where
+	Svc: Service<HttpRequest, Response = HttpResponse, Error = BoxError>,
+	S: h3::quic::SendStream<Bytes> + h3::quic::RecvStream,
+	// B: bytes::Buf,
+{
+	trace!(target: LOG_TARGET, "Handling HTTP/3 request: {:?}", request);
+
+	// Read request body
+	let body = read_body_with_limit(&mut stream, server_cfg.max_request_body_size).await?;
+
+	// Create HTTP request
+	let (parts, _) = request.into_parts();
+	let mut http_request = HttpRequest::from_parts(parts, HttpBody::from(body));
+
+	// Add connection info to extensions
+	http_request.extensions_mut().insert(conn_state.clone());
+	http_request.extensions_mut().insert(methods);
+
+	// Process request through service
+	let response = match service.call(http_request).await {
+		Ok(resp) => resp,
+		Err(e) => {
+			error!(target: LOG_TARGET, "Service error: {}", e);
+			create_error_response(StatusCode::INTERNAL_SERVER_ERROR)
+		}
+	};
+
+	// Send response
+	send_response(stream, response).await
+}
+
+/// Read request body with size limit
+async fn read_body_with_limit<S>(stream: &mut RequestStream<S, Bytes>, max_size: u32) -> Result<Vec<u8>, BoxError>
+where
+	S: h3::quic::RecvStream,
+	// B: bytes::Buf,
+{
+	let mut body = Vec::new();
+	let max_size = max_size as usize;
+
+	while let Some(chunk) = stream.recv_data().await? {
+		if body.len() + chunk.remaining() > max_size {
+			return Err("Request body too large".into());
+		}
+		body.extend_from_slice(chunk.chunk());
+	}
+
+	Ok(body)
+}
+
+/// Send HTTP/3 response
+async fn send_response<S>(mut stream: RequestStream<S, Bytes>, response: HttpResponse) -> Result<(), BoxError>
+where
+	S: h3::quic::SendStream<Bytes>,
+	// B: bytes::Buf,
+{
+	let (parts, body) = response.into_parts();
+
+	// Build H3 response
+	let response = Response::builder().status(parts.status).version(http::Version::HTTP_3);
+
+	let mut response = parts.headers.iter().fold(response, |resp, (name, value)| resp.header(name, value));
+
+	// Collect body
+	let body_bytes = match http_body_util::BodyExt::collect(body).await {
+		Ok(collected) => collected.to_bytes(),
+		Err(e) => {
+			error!(target: LOG_TARGET, "Failed to collect response body: {}", e);
+			Bytes::new()
+		}
+	};
+
+	// Add content-length header
+	response = response.header("content-length", body_bytes.len().to_string());
+
+	let response = response.body(())?;
+
+	// Send response
+	stream.send_response(response).await?;
+
+	if !body_bytes.is_empty() {
+		stream.send_data(body_bytes).await?;
+	}
+
+	stream.finish().await?;
+
+	Ok(())
+}
+
+/// Send error response
+async fn send_error_response<S>(stream: RequestStream<S, Bytes>, status: StatusCode)
+where
+	S: h3::quic::SendStream<Bytes>,
+	// B: bytes::Buf,
+{
+	let response = create_error_response(status);
+	let _ = send_response(stream, response).await;
+}
+
+/// Create error response
+fn create_error_response(status: StatusCode) -> HttpResponse {
+	Response::builder()
+		.status(status)
+		.header("content-type", "text/plain")
+		.body(HttpBody::from(status.to_string()))
+		.unwrap()
+}
+
+/// Create TLS configuration
+fn create_tls_config(cert_config: &CertificateConfig) -> Result<RustlsServerConfig, BoxError> {
+	match cert_config {
+		CertificateConfig::SelfSigned { dns_name } => {
+			// Generate self-signed certificate
+			let cert = rcgen::generate_simple_self_signed(vec![dns_name.clone()])?;
+
+			let cert_der = cert.cert.der().to_vec();
+			let key_der = cert.key_pair.serialize_der();
+
+			// Create rustls certificate and key
+			let cert = rustls::pki_types::CertificateDer::from(cert_der);
+			let key = rustls::pki_types::PrivateKeyDer::from(rustls::pki_types::PrivatePkcs8KeyDer::from(key_der));
+
+			let mut config = rustls::ServerConfig::builder()
+				.with_no_client_auth()
+				.with_single_cert(vec![cert], key)
+				.map_err(|e| format!("Failed to create TLS config: {}", e))?;
+
+			config.alpn_protocols = vec![b"h3".to_vec()];
+			Ok(config)
+		}
+		CertificateConfig::Custom { cert_chain, private_key } => {
+			// Parse PEM certificates
+			let mut cert_reader = std::io::Cursor::new(cert_chain);
+			let certs = rustls_pemfile::certs(&mut cert_reader)
+				.collect::<Result<Vec<_>, _>>()
+				.map_err(|e| format!("Failed to parse certificates: {}", e))?;
+
+			if certs.is_empty() {
+				return Err("No valid certificates found".into());
+			}
+
+			// Parse PEM private key
+			let key = rustls_pemfile::private_key(&mut private_key.as_slice())?.ok_or("No private key found")?;
+
+			let mut config = rustls::ServerConfig::builder()
+				.with_no_client_auth()
+				.with_single_cert(certs, key)
+				.map_err(|e| format!("Failed to create TLS config: {}", e))?;
+
+			config.alpn_protocols = vec![b"h3".to_vec()];
+			Ok(config)
+		}
+	}
+}

--- a/server/src/transport/mod.rs
+++ b/server/src/transport/mod.rs
@@ -2,3 +2,6 @@
 pub mod http;
 /// WebSocket related server functionality.
 pub mod ws;
+
+#[cfg(feature = "http3")]
+pub mod http3;

--- a/tests/tests/metrics.rs
+++ b/tests/tests/metrics.rs
@@ -198,7 +198,7 @@ async fn http_server_logger() {
 	let (server_addr, server_handle) = http_server(test_module(), counter.clone()).await.unwrap();
 
 	let server_url = format!("http://{}", server_addr);
-	let client = HttpClientBuilder::default().build(&server_url).unwrap();
+	let client = HttpClientBuilder::default().build(&server_url).await.unwrap();
 
 	let res: String = client.request("say_hello", rpc_params![]).await.unwrap();
 	assert_eq!(res, "hello");

--- a/tests/tests/proc_macros.rs
+++ b/tests/tests/proc_macros.rs
@@ -383,7 +383,7 @@ async fn subscriptions_do_not_work_for_http_servers() {
 	let htserver_url = format!("http://{}", addr);
 	let _handle = htserver.start(RpcServerImpl.into_rpc());
 
-	let htclient = HttpClientBuilder::default().build(&htserver_url).unwrap();
+	let htclient = HttpClientBuilder::default().build(&htserver_url).await.unwrap();
 
 	assert_eq!(htclient.sync_method().await.unwrap(), 10);
 	assert!(htclient.sub().await.is_err());


### PR DESCRIPTION
An attempt to implement HTTP/3 support address this issue [rise#392](https://github.com/risechain/rise/issues/392).

Please read the `benches/README.md` for bench information.

This PR still didn't support priority-based mechanism described in [RFC 9218](https://www.rfc-editor.org/rfc/rfc9218.html).

The bench results I had so far (output from my script `scripts/bench_http.sh`):

![image](https://github.com/user-attachments/assets/e3e234f3-9078-459f-bd9b-df94290aa937)
